### PR TITLE
feat(documents): course document pipeline API and workspace observability

### DIFF
--- a/apps/web/src/app/courses/[courseId]/documents/[documentId]/preview/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/documents/[documentId]/preview/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { getDocumentPreviewView } from '@/lib/api/documents';
+import type { DocumentPreviewView } from '@/lib/api/types';
+
+export default function DocumentPreviewPage() {
+  const params = useParams();
+  const router = useRouter();
+  const courseId = params.courseId as string;
+  const documentId = params.documentId as string;
+  const { data: session } = useSession();
+  const accessToken = (session?.user as any)?.accessToken;
+
+  const [preview, setPreview] = useState<DocumentPreviewView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await getDocumentPreviewView(documentId, accessToken);
+      setPreview(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load preview');
+    } finally {
+      setLoading(false);
+    }
+  }, [documentId, accessToken]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="animate-pulse space-y-6">
+          <div className="h-6 w-1/3 bg-gray-200 rounded" />
+          <div className="h-64 bg-gray-100 rounded-lg" />
+          <div className="h-40 bg-gray-100 rounded-lg" />
+        </div>
+      </main>
+    );
+  }
+
+  if (error || !preview) {
+    return (
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+          <p className="text-sm text-red-700">{error || 'Preview not available'}</p>
+          <div className="mt-3 flex items-center justify-center gap-3">
+            <button
+              onClick={load}
+              className="text-sm font-medium text-red-700 hover:text-red-800 underline"
+            >
+              Retry
+            </button>
+            <button
+              onClick={() => router.push(`/courses/${courseId}`)}
+              className="text-sm font-medium text-gray-600 hover:text-gray-800 underline"
+            >
+              Back to course
+            </button>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Header */}
+      <div className="mb-6 flex items-center gap-3">
+        <button
+          onClick={() => router.push(`/courses/${courseId}`)}
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+          </svg>
+          Back
+        </button>
+        <div className="flex-1 min-w-0">
+          <h1 className="text-xl font-bold text-gray-900 truncate">{preview.filename}</h1>
+          {preview.pageCount != null && (
+            <p className="text-sm text-gray-500">{preview.pageCount} page{preview.pageCount !== 1 ? 's' : ''}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        {/* Extracted text preview */}
+        <section className="bg-white rounded-lg shadow">
+          <div className="px-6 py-4 border-b border-gray-100">
+            <h2 className="text-base font-semibold text-gray-900">Extracted Text</h2>
+          </div>
+          <div className="p-6">
+            {preview.extractedTextPreview ? (
+              <pre className="text-sm text-gray-800 whitespace-pre-wrap font-mono bg-gray-50 rounded-md p-4 max-h-96 overflow-auto">
+                {preview.extractedTextPreview}
+              </pre>
+            ) : (
+              <p className="text-sm text-gray-400 italic">No extracted text available yet.</p>
+            )}
+          </div>
+        </section>
+
+        {/* Sections / page segmentation */}
+        <section className="bg-white rounded-lg shadow">
+          <div className="px-6 py-4 border-b border-gray-100">
+            <h2 className="text-base font-semibold text-gray-900">Sections / Page Segmentation</h2>
+          </div>
+          <div className="p-6">
+            {preview.sections && preview.sections.length > 0 ? (
+              <div className="space-y-3">
+                {preview.sections.map((section, i) => (
+                  <div key={i} className="rounded-md border border-gray-200 p-3">
+                    <p className="text-xs font-medium text-gray-500 mb-1">Section {i + 1}</p>
+                    <pre className="text-xs text-gray-700 whitespace-pre-wrap font-mono max-h-40 overflow-auto">
+                      {JSON.stringify(section, null, 2)}
+                    </pre>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400 italic">No sections data available yet.</p>
+            )}
+          </div>
+        </section>
+
+        {/* Sample chunks */}
+        <section className="bg-white rounded-lg shadow">
+          <div className="px-6 py-4 border-b border-gray-100">
+            <h2 className="text-base font-semibold text-gray-900">Sample Chunks</h2>
+          </div>
+          <div className="p-6">
+            {preview.sampleChunks && preview.sampleChunks.length > 0 ? (
+              <div className="space-y-3">
+                {preview.sampleChunks.map((chunk, i) => (
+                  <div key={i} className="rounded-md border border-gray-200 p-3">
+                    <p className="text-xs font-medium text-gray-500 mb-1">Chunk {i + 1}</p>
+                    <pre className="text-xs text-gray-700 whitespace-pre-wrap font-mono max-h-40 overflow-auto">
+                      {typeof chunk === 'string' ? chunk : JSON.stringify(chunk, null, 2)}
+                    </pre>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400 italic">No chunk samples available yet.</p>
+            )}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/courses/[courseId]/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { getCourse, getCourseLessons, type Course, type Lesson } from '@/lib/services/courses';
 import { DocumentList } from '@/components/courses/DocumentList';
@@ -9,6 +9,7 @@ import { DocumentUpload } from '@/components/documents/DocumentUpload';
 
 export default function CourseWorkspacePage() {
   const params = useParams();
+  const router = useRouter();
   const courseId = params.courseId as string;
   const { data: session } = useSession();
   const accessToken = (session?.user as any)?.accessToken;
@@ -22,6 +23,10 @@ export default function CourseWorkspacePage() {
   const refreshDocuments = useCallback(() => {
     setDocRefreshKey((k) => k + 1);
   }, []);
+
+  function handleViewPreview(documentId: string) {
+    router.push(`/courses/${courseId}/documents/${documentId}/preview`);
+  }
 
   useEffect(() => {
     async function load() {
@@ -140,6 +145,7 @@ export default function CourseWorkspacePage() {
                   courseId={courseId}
                   accessToken={accessToken}
                   refreshKey={docRefreshKey}
+                  onViewPreview={handleViewPreview}
                 />
               </div>
             </div>

--- a/apps/web/src/components/courses/DocumentList.tsx
+++ b/apps/web/src/components/courses/DocumentList.tsx
@@ -1,15 +1,19 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import type { CourseDocument } from '@/lib/services/documents';
-import { getDocuments } from '@/lib/services/documents';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getDocumentListRows } from '@/lib/api/documents';
+import type { DocumentListRow } from '@/lib/api/types';
 import { ProcessingIndicator } from './ProcessingIndicator';
+import { DocumentProcessingPanel } from '@/components/documents/DocumentProcessingPanel';
 
 interface DocumentListProps {
   courseId: string;
   accessToken?: string;
   refreshKey?: number;
+  onViewPreview?: (documentId: string) => void;
 }
+
+const AUTO_POLL_INTERVAL_MS = 8000;
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -17,33 +21,76 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function DocumentList({ courseId, accessToken, refreshKey = 0 }: DocumentListProps) {
-  const [documents, setDocuments] = useState<CourseDocument[]>([]);
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function DocumentList({
+  courseId,
+  accessToken,
+  refreshKey = 0,
+  onViewPreview,
+}: DocumentListProps) {
+  const [documents, setDocuments] = useState<DocumentListRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const fetchDocuments = useCallback(async () => {
-    try {
-      setError(null);
-      const docs = await getDocuments(courseId, accessToken);
-      setDocuments(docs);
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : 'Failed to load documents';
-      if (message.includes('Request failed (404)') || message.includes('Request failed (50')) {
-        setDocuments([]);
-        setError(null);
-      } else {
-        setError(message);
+  const fetchDocuments = useCallback(
+    async (silent = false) => {
+      try {
+        if (!silent) setError(null);
+        const rows = await getDocumentListRows(courseId, accessToken);
+        setDocuments(rows);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to load documents';
+        if (message.includes('Request failed (404)') || message.includes('Request failed (50')) {
+          setDocuments([]);
+          setError(null);
+        } else if (!silent) {
+          setError(message);
+        }
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
       }
-    } finally {
-      setLoading(false);
-    }
-  }, [courseId, accessToken]);
+    },
+    [courseId, accessToken],
+  );
 
   useEffect(() => {
     fetchDocuments();
   }, [fetchDocuments, refreshKey]);
+
+  useEffect(() => {
+    const hasInProgress = documents.some((d) => !d.isTerminal);
+    if (hasInProgress) {
+      pollRef.current = setInterval(() => fetchDocuments(true), AUTO_POLL_INTERVAL_MS);
+    }
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [documents, fetchDocuments]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchDocuments();
+  }
+
+  function toggleExpand(id: string) {
+    setExpandedId((prev) => (prev === id ? null : id));
+  }
 
   if (loading) {
     return (
@@ -66,7 +113,7 @@ export function DocumentList({ courseId, accessToken, refreshKey = 0 }: Document
       <div className="rounded-lg border border-red-200 bg-red-50 p-4">
         <p className="text-sm text-red-700">{error}</p>
         <button
-          onClick={fetchDocuments}
+          onClick={() => fetchDocuments()}
           className="mt-2 text-sm font-medium text-red-700 hover:text-red-800 underline"
         >
           Retry
@@ -78,8 +125,18 @@ export function DocumentList({ courseId, accessToken, refreshKey = 0 }: Document
   if (documents.length === 0) {
     return (
       <div className="text-center py-8 px-4">
-        <svg className="mx-auto h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m6.75 12H9.75m3 0h.008v.008H12.75v-.008zM12 18.75h.008v.008H12v-.008zm-3 0h.008v.008H9v-.008zm6-6h.008v.008h-.008v-.008zm-3 0h.008v.008H12v-.008zm-3 0h.008v.008H9v-.008z" />
+        <svg
+          className="mx-auto h-10 w-10 text-gray-300"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m6.75 12H9.75m3 0h.008v.008H12.75v-.008zM12 18.75h.008v.008H12v-.008zm-3 0h.008v.008H9v-.008zm6-6h.008v.008h-.008v-.008zm-3 0h.008v.008H12v-.008zm-3 0h.008v.008H9v-.008z"
+          />
         </svg>
         <p className="mt-2 text-sm text-gray-500">No documents uploaded yet</p>
         <p className="text-xs text-gray-400">Upload slides, notes, or reference material to get started</p>
@@ -88,21 +145,97 @@ export function DocumentList({ courseId, accessToken, refreshKey = 0 }: Document
   }
 
   return (
-    <ul className="divide-y divide-gray-100">
-      {documents.map((doc) => (
-        <li key={doc.id} className="flex items-center gap-3 py-3 px-1">
-          <div className="flex-shrink-0">
-            <svg className="h-7 w-7 text-gray-400" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
-            </svg>
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-gray-900 truncate">{doc.filename}</p>
-            <p className="text-xs text-gray-500">{formatFileSize(doc.size)}</p>
-          </div>
-          <ProcessingIndicator status={doc.status} />
-        </li>
-      ))}
-    </ul>
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs text-gray-500">
+          {documents.length} document{documents.length !== 1 ? 's' : ''}
+        </p>
+        <button
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 disabled:opacity-50"
+          title="Refresh list"
+        >
+          <svg
+            className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182"
+            />
+          </svg>
+          {refreshing ? 'Refreshing...' : 'Refresh'}
+        </button>
+      </div>
+
+      <ul className="divide-y divide-gray-100">
+        {documents.map((doc) => {
+          const isExpanded = expandedId === doc.id;
+          return (
+            <li key={doc.id} className="py-2 px-1">
+              <button
+                type="button"
+                onClick={() => toggleExpand(doc.id)}
+                className="w-full text-left rounded-md hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+                aria-expanded={isExpanded}
+              >
+                <div className="flex items-start gap-3">
+                  {/* Expand chevron */}
+                  <svg
+                    className={`mt-1 h-4 w-4 flex-shrink-0 text-gray-400 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2}
+                    stroke="currentColor"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                  </svg>
+
+                  {/* File type badge */}
+                  <span className="flex-shrink-0 mt-0.5 inline-flex items-center justify-center h-8 w-8 rounded-md bg-gray-100 text-[10px] font-bold text-gray-500 uppercase">
+                    {doc.fileType}
+                  </span>
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-medium text-gray-900 truncate">{doc.filename}</p>
+                      <ProcessingIndicator status={doc.status} stage={doc.processingStage} />
+                    </div>
+
+                    <div className="mt-0.5 flex items-center gap-3 text-xs text-gray-500">
+                      <span>{formatFileSize(doc.size)}</span>
+                      <span title="Uploaded">{formatTime(doc.createdAt)}</span>
+                      <span title="Last updated">updated {formatTime(doc.updatedAt)}</span>
+                    </div>
+
+                    {doc.status === 'error' && doc.errorMessage && (
+                      <p className="mt-1 text-xs text-red-600 truncate" title={doc.errorMessage}>
+                        {doc.errorMessage}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </button>
+
+              {/* Expandable detail panel (U-05) */}
+              {isExpanded && (
+                <div className="mt-2 ml-7">
+                  <DocumentProcessingPanel
+                    documentId={doc.id}
+                    accessToken={accessToken}
+                    onViewPreview={onViewPreview}
+                  />
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 }

--- a/apps/web/src/components/courses/ProcessingIndicator.tsx
+++ b/apps/web/src/components/courses/ProcessingIndicator.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import type { DocumentStatus } from '@/lib/services/documents';
+import type { DocumentStatus, ProcessingStage } from '@/lib/api/types';
 
 interface ProcessingIndicatorProps {
   status: DocumentStatus;
-  progress?: number;
+  stage?: ProcessingStage;
   className?: string;
 }
 
@@ -35,8 +35,20 @@ const STATUS_CONFIG: Record<DocumentStatus, { label: string; bg: string; text: s
   },
 };
 
-export function ProcessingIndicator({ status, progress, className = '' }: ProcessingIndicatorProps) {
+const STAGE_LABELS: Record<ProcessingStage, string> = {
+  queued: 'Queued',
+  uploading: 'Uploading',
+  parsing: 'Parsing',
+  normalizing: 'Normalizing',
+  chunking: 'Chunking',
+  indexing: 'Indexing',
+  done: 'Done',
+  error: 'Error',
+};
+
+export function ProcessingIndicator({ status, stage, className = '' }: ProcessingIndicatorProps) {
   const config = STATUS_CONFIG[status];
+  const stageLabel = stage && stage !== 'done' && stage !== 'error' ? STAGE_LABELS[stage] : null;
 
   return (
     <span
@@ -44,8 +56,8 @@ export function ProcessingIndicator({ status, progress, className = '' }: Proces
     >
       <span className={`h-1.5 w-1.5 rounded-full ${config.dot}`} />
       {config.label}
-      {status === 'processing' && progress != null && (
-        <span className="tabular-nums">{Math.round(progress)}%</span>
+      {stageLabel && status === 'processing' && (
+        <span className="opacity-75">· {stageLabel}</span>
       )}
     </span>
   );

--- a/apps/web/src/components/documents/DocumentProcessingPanel.tsx
+++ b/apps/web/src/components/documents/DocumentProcessingPanel.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { getDocumentDetailView } from '@/lib/api/documents';
+import type { DocumentDetailView } from '@/lib/api/types';
+
+interface DocumentProcessingPanelProps {
+  documentId: string;
+  accessToken?: string;
+  onViewPreview?: (documentId: string) => void;
+}
+
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between py-1.5">
+      <dt className="text-xs font-medium text-gray-500 w-36 flex-shrink-0">{label}</dt>
+      <dd className="text-xs text-gray-900 text-right">{value ?? <span className="text-gray-400">N/A</span>}</dd>
+    </div>
+  );
+}
+
+export function DocumentProcessingPanel({
+  documentId,
+  accessToken,
+  onViewPreview,
+}: DocumentProcessingPanelProps) {
+  const [detail, setDetail] = useState<DocumentDetailView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setError(null);
+      const data = await getDocumentDetailView(documentId, accessToken);
+      setDetail(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load document details');
+    } finally {
+      setLoading(false);
+    }
+  }, [documentId, accessToken]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="animate-pulse space-y-2 py-3 px-4">
+        <div className="h-3 w-2/3 rounded bg-gray-200" />
+        <div className="h-3 w-1/2 rounded bg-gray-200" />
+        <div className="h-3 w-3/4 rounded bg-gray-200" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="py-3 px-4">
+        <p className="text-xs text-red-600">{error}</p>
+        <button onClick={load} className="mt-1 text-xs text-red-700 hover:text-red-800 underline">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!detail) return null;
+
+  return (
+    <div className="py-3 px-4 bg-gray-50 rounded-md space-y-1">
+      <dl className="divide-y divide-gray-100">
+        <DetailRow label="Raw status" value={detail.status} />
+        <DetailRow label="Processing stage" value={detail.processingStage} />
+        <DetailRow label="Parser used" value={detail.parserUsed} />
+        <DetailRow label="Page / slide count" value={detail.pageCount} />
+        <DetailRow label="Chunk count" value={detail.chunkCount} />
+        <DetailRow label="Indexing status" value={detail.indexingStatus} />
+        {detail.errorMessage && (
+          <DetailRow
+            label="Processing errors"
+            value={<span className="text-red-600">{detail.errorMessage}</span>}
+          />
+        )}
+        {detail.normalizedMetadata && (
+          <div className="py-1.5">
+            <dt className="text-xs font-medium text-gray-500 mb-1">Normalized metadata</dt>
+            <dd className="text-[11px] font-mono bg-white rounded border border-gray-200 p-2 max-h-32 overflow-auto whitespace-pre-wrap">
+              {JSON.stringify(detail.normalizedMetadata, null, 2)}
+            </dd>
+          </div>
+        )}
+      </dl>
+
+      {onViewPreview && detail.status === 'ready' && (
+        <button
+          onClick={() => onViewPreview(detail.id)}
+          className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-orange-600 hover:text-orange-700"
+        >
+          View extracted content
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/documents/DocumentRow.tsx
+++ b/apps/web/src/components/documents/DocumentRow.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import type { CourseDocument } from '@/lib/services/documents';
-import { deleteDocument } from '@/lib/services/documents';
+import type { DocumentListRow } from '@/lib/api/types';
+import { deleteDocument } from '@/lib/api/documents';
 import { ProcessingIndicator } from '@/components/courses/ProcessingIndicator';
 
 interface DocumentRowProps {
-  document: CourseDocument;
+  document: DocumentListRow;
   accessToken?: string;
   onDeleted?: () => void;
 }

--- a/apps/web/src/components/documents/DocumentUpload.tsx
+++ b/apps/web/src/components/documents/DocumentUpload.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useRef, useState } from 'react';
-import { uploadDocument, pollDocumentStatus } from '@/lib/services/documents';
+import { uploadDocument, pollDocumentUntilTerminal } from '@/lib/api/documents';
 
 interface DocumentUploadProps {
   courseId: string;
@@ -45,7 +45,7 @@ export function DocumentUpload({ courseId, accessToken, onUploadComplete }: Docu
             return updated;
           });
 
-          await pollDocumentStatus(doc.id, accessToken);
+          await pollDocumentUntilTerminal(doc.id, accessToken);
 
           setJobs((prev) => {
             const updated = [...prev];

--- a/apps/web/src/lib/api/adapters.ts
+++ b/apps/web/src/lib/api/adapters.ts
@@ -1,0 +1,81 @@
+import type {
+  ApiDocumentListItem,
+  ApiDocumentDetail,
+  ApiDocumentPreview,
+  DocumentListRow,
+  DocumentDetailView,
+  DocumentPreviewView,
+  DocumentStatus,
+  ProcessingStage,
+} from './types';
+
+function mimeToLabel(mime: string | null, filename: string): string {
+  if (mime) {
+    const sub = mime.split('/')[1];
+    if (sub === 'pdf') return 'PDF';
+    if (sub === 'vnd.openxmlformats-officedocument.presentationml.presentation') return 'PPTX';
+    if (sub === 'vnd.openxmlformats-officedocument.wordprocessingml.document') return 'DOCX';
+    if (sub === 'plain') return 'TXT';
+    if (sub) return sub.toUpperCase();
+  }
+  const ext = filename.split('.').pop()?.toUpperCase();
+  return ext || 'FILE';
+}
+
+const TERMINAL_STATUSES: ReadonlySet<DocumentStatus> = new Set(['ready', 'error']);
+
+export function toDocumentListRow(item: ApiDocumentListItem): DocumentListRow {
+  return {
+    id: item.id,
+    courseId: item.course_id,
+    filename: item.filename,
+    fileType: mimeToLabel(item.mime_type, item.filename),
+    size: item.size,
+    status: item.status,
+    processingStage: item.processing_stage,
+    isTerminal: TERMINAL_STATUSES.has(item.status),
+    errorMessage: item.error_message,
+    createdAt: item.created_at,
+    updatedAt: item.updated_at,
+  };
+}
+
+export function toDocumentDetailView(item: ApiDocumentDetail): DocumentDetailView {
+  let normalizedMetadata: Record<string, unknown> | null = null;
+  if (item.metadata_json) {
+    try {
+      normalizedMetadata = JSON.parse(item.metadata_json);
+    } catch {
+      normalizedMetadata = null;
+    }
+  }
+
+  return {
+    id: item.id,
+    courseId: item.course_id,
+    filename: item.filename,
+    fileType: mimeToLabel(item.mime_type, item.filename),
+    size: item.size,
+    status: item.status,
+    processingStage: item.processing_stage,
+    errorMessage: item.error_message,
+    parserUsed: item.parser_used,
+    pageCount: item.page_count,
+    chunkCount: item.chunk_count,
+    indexingStatus: item.indexing_status,
+    normalizedMetadata,
+    createdAt: item.created_at,
+    updatedAt: item.updated_at,
+  };
+}
+
+export function toDocumentPreviewView(item: ApiDocumentPreview): DocumentPreviewView {
+  return {
+    id: item.id,
+    filename: item.filename,
+    extractedTextPreview: item.extracted_text_preview,
+    pageCount: item.page_count,
+    sections: item.sections,
+    sampleChunks: item.sample_chunks,
+  };
+}

--- a/apps/web/src/lib/api/courses.ts
+++ b/apps/web/src/lib/api/courses.ts
@@ -1,0 +1,37 @@
+import { apiFetch } from '@/lib/api';
+import type { ApiCourse, ApiLesson, CreateCourseRequest } from './types';
+
+export async function fetchCourses(
+  skip = 0,
+  limit = 100,
+  accessToken?: string,
+): Promise<ApiCourse[]> {
+  return apiFetch<ApiCourse[]>(`/courses?skip=${skip}&limit=${limit}`, {
+    accessToken,
+  });
+}
+
+export async function fetchCourse(
+  courseId: string,
+  accessToken?: string,
+): Promise<ApiCourse> {
+  return apiFetch<ApiCourse>(`/courses/${courseId}`, { accessToken });
+}
+
+export async function fetchCourseLessons(
+  courseId: string,
+  accessToken?: string,
+): Promise<ApiLesson[]> {
+  return apiFetch<ApiLesson[]>(`/courses/${courseId}/lessons`, { accessToken });
+}
+
+export async function createCourse(
+  data: CreateCourseRequest,
+  accessToken?: string,
+): Promise<ApiCourse> {
+  return apiFetch<ApiCourse>('/courses', {
+    method: 'POST',
+    body: data,
+    accessToken,
+  });
+}

--- a/apps/web/src/lib/api/documents.ts
+++ b/apps/web/src/lib/api/documents.ts
@@ -1,0 +1,125 @@
+import { apiFetch, ApiError } from '@/lib/api';
+import type {
+  ApiDocumentListItem,
+  ApiDocumentDetail,
+  ApiDocumentPreview,
+  ApiDocumentStatusResponse,
+  DocumentListRow,
+  DocumentDetailView,
+  DocumentPreviewView,
+} from './types';
+import { toDocumentListRow, toDocumentDetailView, toDocumentPreviewView } from './adapters';
+
+// ── Raw API calls (wire types) ──────────────────────────────────────────
+
+export async function fetchDocumentsList(
+  courseId: string,
+  accessToken?: string,
+): Promise<ApiDocumentListItem[]> {
+  return apiFetch<ApiDocumentListItem[]>(`/courses/${courseId}/documents`, {
+    accessToken,
+  });
+}
+
+export async function fetchDocumentStatus(
+  documentId: string,
+  accessToken?: string,
+): Promise<ApiDocumentStatusResponse> {
+  return apiFetch<ApiDocumentStatusResponse>(`/documents/${documentId}/status`, {
+    accessToken,
+  });
+}
+
+export async function fetchDocumentDetail(
+  documentId: string,
+  accessToken?: string,
+): Promise<ApiDocumentDetail> {
+  return apiFetch<ApiDocumentDetail>(`/documents/${documentId}`, {
+    accessToken,
+  });
+}
+
+export async function fetchDocumentPreview(
+  documentId: string,
+  accessToken?: string,
+): Promise<ApiDocumentPreview> {
+  return apiFetch<ApiDocumentPreview>(`/documents/${documentId}/preview`, {
+    accessToken,
+  });
+}
+
+export async function uploadDocument(
+  courseId: string,
+  file: File,
+  accessToken?: string,
+): Promise<ApiDocumentListItem> {
+  const formData = new FormData();
+  formData.append('file', file);
+  return apiFetch<ApiDocumentListItem>(`/courses/${courseId}/documents`, {
+    method: 'POST',
+    body: formData,
+    accessToken,
+  });
+}
+
+export async function deleteDocument(
+  documentId: string,
+  accessToken?: string,
+): Promise<{ message: string }> {
+  return apiFetch<{ message: string }>(`/documents/${documentId}`, {
+    method: 'DELETE',
+    accessToken,
+  });
+}
+
+// ── Adapted calls (UI types) ───────────────────────────────────────────
+
+export async function getDocumentListRows(
+  courseId: string,
+  accessToken?: string,
+): Promise<DocumentListRow[]> {
+  const items = await fetchDocumentsList(courseId, accessToken);
+  return items.map(toDocumentListRow);
+}
+
+export async function getDocumentDetailView(
+  documentId: string,
+  accessToken?: string,
+): Promise<DocumentDetailView> {
+  const item = await fetchDocumentDetail(documentId, accessToken);
+  return toDocumentDetailView(item);
+}
+
+export async function getDocumentPreviewView(
+  documentId: string,
+  accessToken?: string,
+): Promise<DocumentPreviewView> {
+  const item = await fetchDocumentPreview(documentId, accessToken);
+  return toDocumentPreviewView(item);
+}
+
+// ── Polling helper ──────────────────────────────────────────────────────
+
+export async function pollDocumentUntilTerminal(
+  documentId: string,
+  accessToken?: string,
+  intervalMs = 3000,
+  maxAttempts = 60,
+): Promise<ApiDocumentStatusResponse> {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const status = await fetchDocumentStatus(documentId, accessToken);
+      if (status.status === 'ready' || status.status === 'error') {
+        return status;
+      }
+    } catch (err) {
+      if (err instanceof ApiError && err.status >= 500) {
+        // transient — keep polling
+      } else {
+        throw err;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error('Document processing timed out');
+}

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './adapters';
+export * from './documents';
+export * from './courses';

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -1,0 +1,121 @@
+// ── Processing pipeline stages ──────────────────────────────────────────
+export type ProcessingStage =
+  | 'queued'
+  | 'uploading'
+  | 'parsing'
+  | 'normalizing'
+  | 'chunking'
+  | 'indexing'
+  | 'done'
+  | 'error';
+
+export type DocumentStatus = 'uploading' | 'processing' | 'ready' | 'error';
+
+// ── Wire types (raw JSON from API) ─────────────────────────────────────
+
+export interface ApiCourse {
+  id: number | string;
+  title: string;
+  description?: string;
+}
+
+export interface ApiLesson {
+  id: number | string;
+  title: string;
+  content?: string;
+}
+
+export interface ApiDocumentListItem {
+  id: string;
+  course_id: string;
+  filename: string;
+  mime_type: string | null;
+  size: number;
+  status: DocumentStatus;
+  processing_stage: ProcessingStage;
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ApiDocumentStatusResponse {
+  id: string;
+  status: DocumentStatus;
+  processing_stage: ProcessingStage;
+  error_message: string | null;
+}
+
+export interface ApiDocumentDetail {
+  id: string;
+  course_id: string;
+  filename: string;
+  mime_type: string | null;
+  size: number;
+  status: DocumentStatus;
+  processing_stage: ProcessingStage;
+  error_message: string | null;
+  parser_used: string | null;
+  page_count: number | null;
+  chunk_count: number | null;
+  indexing_status: string | null;
+  metadata_json: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ApiDocumentPreview {
+  id: string;
+  filename: string;
+  extracted_text_preview: string | null;
+  page_count: number | null;
+  sections: Array<Record<string, unknown>> | null;
+  sample_chunks: Array<Record<string, unknown>> | null;
+}
+
+export interface CreateCourseRequest {
+  title: string;
+  description?: string;
+}
+
+// ── UI types (consumed by components) ───────────────────────────────────
+
+export interface DocumentListRow {
+  id: string;
+  courseId: string;
+  filename: string;
+  fileType: string;
+  size: number;
+  status: DocumentStatus;
+  processingStage: ProcessingStage;
+  isTerminal: boolean;
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DocumentDetailView {
+  id: string;
+  courseId: string;
+  filename: string;
+  fileType: string;
+  size: number;
+  status: DocumentStatus;
+  processingStage: ProcessingStage;
+  errorMessage: string | null;
+  parserUsed: string | null;
+  pageCount: number | null;
+  chunkCount: number | null;
+  indexingStatus: string | null;
+  normalizedMetadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DocumentPreviewView {
+  id: string;
+  filename: string;
+  extractedTextPreview: string | null;
+  pageCount: number | null;
+  sections: Array<Record<string, unknown>> | null;
+  sampleChunks: Array<Record<string, unknown>> | null;
+}

--- a/services/ai/app/api/documents_api.py
+++ b/services/ai/app/api/documents_api.py
@@ -1,0 +1,105 @@
+"""Documents API controller - upload, list, status, detail, preview."""
+from typing import List
+
+from fastapi import APIRouter, Depends, Path, UploadFile, File
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.services import document_service
+from app.schemas.document_schemas import (
+    DocumentDetail,
+    DocumentListItem,
+    DocumentPreview,
+    DocumentStatusResponse,
+)
+from app.core.errors import NotFoundError
+
+router = APIRouter(prefix="/api", tags=["Documents"])
+
+
+@router.get(
+    "/courses/{course_id}/documents",
+    response_model=List[DocumentListItem],
+)
+def list_documents(
+    course_id: str = Path(..., description="Course ID"),
+    db: Session = Depends(get_db),
+) -> List[DocumentListItem]:
+    return document_service.list_documents(db, course_id)
+
+
+@router.post(
+    "/courses/{course_id}/documents",
+    response_model=DocumentListItem,
+    status_code=201,
+)
+def upload_document(
+    course_id: str = Path(..., description="Course ID"),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+) -> DocumentListItem:
+    content = file.file.read()
+    doc = document_service.create_document(
+        db,
+        course_id=course_id,
+        filename=file.filename or "unknown",
+        size=len(content),
+        mime_type=file.content_type,
+    )
+    return doc
+
+
+@router.get(
+    "/documents/{document_id}/status",
+    response_model=DocumentStatusResponse,
+)
+def get_document_status(
+    document_id: str = Path(..., description="Document ID"),
+    db: Session = Depends(get_db),
+) -> DocumentStatusResponse:
+    doc = document_service.get_document(db, document_id)
+    if doc is None:
+        raise NotFoundError(resource="Document", identifier=document_id)
+    return doc
+
+
+@router.get(
+    "/documents/{document_id}",
+    response_model=DocumentDetail,
+)
+def get_document_detail(
+    document_id: str = Path(..., description="Document ID"),
+    db: Session = Depends(get_db),
+) -> DocumentDetail:
+    doc = document_service.get_document(db, document_id)
+    if doc is None:
+        raise NotFoundError(resource="Document", identifier=document_id)
+    return doc
+
+
+@router.get(
+    "/documents/{document_id}/preview",
+    response_model=DocumentPreview,
+)
+def get_document_preview(
+    document_id: str = Path(..., description="Document ID"),
+    db: Session = Depends(get_db),
+) -> DocumentPreview:
+    preview = document_service.get_preview(db, document_id)
+    if preview is None:
+        raise NotFoundError(resource="Document", identifier=document_id)
+    return preview
+
+
+@router.delete(
+    "/documents/{document_id}",
+    status_code=200,
+)
+def delete_document(
+    document_id: str = Path(..., description="Document ID"),
+    db: Session = Depends(get_db),
+):
+    deleted = document_service.delete_document(db, document_id)
+    if not deleted:
+        raise NotFoundError(resource="Document", identifier=document_id)
+    return {"message": "Document deleted"}

--- a/services/ai/app/db/models.py
+++ b/services/ai/app/db/models.py
@@ -42,6 +42,24 @@ class ResourceParentType(str, Enum):
     LESSON = "lesson"
 
 
+class DocumentProcessingStage(str, Enum):
+    QUEUED = "queued"
+    UPLOADING = "uploading"
+    PARSING = "parsing"
+    NORMALIZING = "normalizing"
+    CHUNKING = "chunking"
+    INDEXING = "indexing"
+    DONE = "done"
+    ERROR = "error"
+
+
+class DocumentStatus(str, Enum):
+    UPLOADING = "uploading"
+    PROCESSING = "processing"
+    READY = "ready"
+    ERROR = "error"
+
+
 # 1. Users
 class User(Base):
     __tablename__ = "app_user"
@@ -103,6 +121,7 @@ class Course(Base):
 
     section: Mapped["Section"] = relationship(back_populates="courses")
     chapters: Mapped[List["Chapter"]] = relationship(back_populates="course")
+    documents: Mapped[List["CourseDocument"]] = relationship(back_populates="course")
     progress: Mapped[List["UserCourseProgress"]
                      ] = relationship(back_populates="course")
     certificates: Mapped[List["Certificate"]
@@ -313,7 +332,41 @@ class UserCourseProgress(Base):
     course: Mapped["Course"] = relationship(back_populates="progress")
 
 
-# 5. Supplemental Materials
+# 5. Course Documents (uploaded materials for processing pipeline)
+class CourseDocument(Base):
+    __tablename__ = "course_document"
+
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    course_id: Mapped[str] = mapped_column(ForeignKey("course.id"))
+    filename: Mapped[str] = mapped_column(String)
+    mime_type: Mapped[Optional[str]] = mapped_column(String)
+    size: Mapped[int] = mapped_column(Integer, default=0)
+    status: Mapped[str] = mapped_column(String, default=DocumentStatus.UPLOADING)
+    processing_stage: Mapped[str] = mapped_column(
+        String, default=DocumentProcessingStage.QUEUED
+    )
+    error_message: Mapped[Optional[str]] = mapped_column(Text)
+
+    parser_used: Mapped[Optional[str]] = mapped_column(String)
+    page_count: Mapped[Optional[int]] = mapped_column(Integer)
+    chunk_count: Mapped[Optional[int]] = mapped_column(Integer)
+    indexing_status: Mapped[Optional[str]] = mapped_column(String)
+    metadata_json: Mapped[Optional[str]] = mapped_column(Text)
+    extracted_text_preview: Mapped[Optional[str]] = mapped_column(Text)
+    sections_json: Mapped[Optional[str]] = mapped_column(Text)
+    sample_chunks_json: Mapped[Optional[str]] = mapped_column(Text)
+
+    created_at: Mapped[datetime] = mapped_column(String, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        String, default=func.now(), onupdate=func.now()
+    )
+
+    course: Mapped["Course"] = relationship(back_populates="documents")
+
+
+# 6. Supplemental Materials
 class Resource(Base):
     __tablename__ = "resource"
 

--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 
 from app.api.auth_api import router as auth_router
 from app.api.courses_api import router as courses_router
+from app.api.documents_api import router as documents_router
 from app.db.session import init_db, get_db
 from app.core.config import settings
 from app.core.errors import register_exception_handlers
@@ -110,6 +111,7 @@ app.add_middleware(
 # Include routers
 app.include_router(auth_router)
 app.include_router(courses_router)
+app.include_router(documents_router)
 
 
 @app.get("/", tags=["Root"])

--- a/services/ai/app/repositories/document_repo.py
+++ b/services/ai/app/repositories/document_repo.py
@@ -1,0 +1,32 @@
+"""Document repository - data access for course documents."""
+import json
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.db.models import CourseDocument
+
+
+def list_by_course(db: Session, course_id: str) -> List[CourseDocument]:
+    return (
+        db.query(CourseDocument)
+        .filter(CourseDocument.course_id == course_id)
+        .order_by(CourseDocument.created_at.desc())
+        .all()
+    )
+
+
+def get_by_id(db: Session, document_id: str) -> Optional[CourseDocument]:
+    return db.query(CourseDocument).filter(CourseDocument.id == document_id).first()
+
+
+def create(db: Session, doc: CourseDocument) -> CourseDocument:
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    return doc
+
+
+def delete(db: Session, doc: CourseDocument) -> None:
+    db.delete(doc)
+    db.commit()

--- a/services/ai/app/schemas/document_schemas.py
+++ b/services/ai/app/schemas/document_schemas.py
@@ -1,0 +1,59 @@
+"""Pydantic schemas for document DTOs."""
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel
+
+
+class DocumentListItem(BaseModel):
+    id: str
+    course_id: str
+    filename: str
+    mime_type: Optional[str] = None
+    size: int
+    status: str
+    processing_stage: str
+    error_message: Optional[str] = None
+    created_at: str
+    updated_at: str
+
+    class Config:
+        orm_mode = True
+
+
+class DocumentStatusResponse(BaseModel):
+    id: str
+    status: str
+    processing_stage: str
+    error_message: Optional[str] = None
+
+
+class DocumentDetail(BaseModel):
+    id: str
+    course_id: str
+    filename: str
+    mime_type: Optional[str] = None
+    size: int
+    status: str
+    processing_stage: str
+    error_message: Optional[str] = None
+    parser_used: Optional[str] = None
+    page_count: Optional[int] = None
+    chunk_count: Optional[int] = None
+    indexing_status: Optional[str] = None
+    metadata_json: Optional[str] = None
+    created_at: str
+    updated_at: str
+
+    class Config:
+        orm_mode = True
+
+
+class DocumentPreview(BaseModel):
+    id: str
+    filename: str
+    extracted_text_preview: Optional[str] = None
+    page_count: Optional[int] = None
+    sections: Optional[List[Dict[str, Any]]] = None
+    sample_chunks: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        orm_mode = True

--- a/services/ai/app/services/document_service.py
+++ b/services/ai/app/services/document_service.py
@@ -1,0 +1,73 @@
+"""Document service - business logic for document upload, status, and preview."""
+import json
+import uuid
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.db.models import CourseDocument, DocumentProcessingStage, DocumentStatus
+from app.repositories import document_repo
+
+
+def list_documents(db: Session, course_id: str) -> List[CourseDocument]:
+    return document_repo.list_by_course(db, course_id)
+
+
+def get_document(db: Session, document_id: str) -> Optional[CourseDocument]:
+    return document_repo.get_by_id(db, document_id)
+
+
+def create_document(
+    db: Session,
+    course_id: str,
+    filename: str,
+    size: int,
+    mime_type: Optional[str] = None,
+) -> CourseDocument:
+    doc = CourseDocument(
+        id=str(uuid.uuid4()),
+        course_id=course_id,
+        filename=filename,
+        mime_type=mime_type,
+        size=size,
+        status=DocumentStatus.PROCESSING,
+        processing_stage=DocumentProcessingStage.QUEUED,
+    )
+    return document_repo.create(db, doc)
+
+
+def delete_document(db: Session, document_id: str) -> bool:
+    doc = document_repo.get_by_id(db, document_id)
+    if doc is None:
+        return False
+    document_repo.delete(db, doc)
+    return True
+
+
+def get_preview(db: Session, document_id: str) -> Optional[Dict[str, Any]]:
+    doc = document_repo.get_by_id(db, document_id)
+    if doc is None:
+        return None
+
+    sections = None
+    if doc.sections_json:
+        try:
+            sections = json.loads(doc.sections_json)
+        except json.JSONDecodeError:
+            sections = None
+
+    sample_chunks = None
+    if doc.sample_chunks_json:
+        try:
+            sample_chunks = json.loads(doc.sample_chunks_json)
+        except json.JSONDecodeError:
+            sample_chunks = None
+
+    return {
+        "id": doc.id,
+        "filename": doc.filename,
+        "extracted_text_preview": doc.extracted_text_preview,
+        "page_count": doc.page_count,
+        "sections": sections,
+        "sample_chunks": sample_chunks,
+    }


### PR DESCRIPTION
Add first-class support for uploaded course materials on the Bitcoin Academy platform: persistent storage, HTTP API, and UI so teams can trace processing without relying on the shell.

Backend (services/ai)
- Introduce CourseDocument with status, pipeline stage, parser and indexing fields, optional JSON/text columns for metadata, sections, and chunk samples.
- Register REST resources under /api: list and multipart upload by course; lightweight status; full detail; preview payload; delete.
- Integrate the documents router with the existing FastAPI application and schema creation flow.

Frontend (apps/web)
- Add a typed API layer (request/response shapes, UI adapters, shared fetch) for courses and documents, including polling helpers for long-running jobs.
- Enrich the course workspace document list with file type, timestamps, pipeline stage, outcome badges, error surfacing, manual refresh, and automatic refresh while any document is still in progress.
- Provide an expandable processing detail panel backed by the document detail endpoint, and a dedicated preview page for extracted text, segmentation, normalized sections, and sample chunks.

The standalone api/main.py prototype is not used by the web app (different base path and response shapes). Document operations are now owned by the primary AI service so the Next.js client and backend stay contract-aligned.