### PR TITLE
QVAC SDK integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
 
@@ -85,3 +85,27 @@ jobs:
 
       - name: Run tests (Jest)
         run: npm test -- --ci --passWithNoTests
+
+  qvac-service:
+    name: QVAC Service (Node.js)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: workers/qvac-service
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: workers/qvac-service/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ An open-source, local-first platform for structured Bitcoin education. Transform
 
 ### Prerequisites
 
-- Node.js 18+
-- Python 3.10+
-- PostgreSQL (running and accessible)
+| Requirement | Version | Notes |
+|---|---|---|
+| Node.js | **≥ 22.17** | Required by `@qvac/sdk` (bare runtime shims). |
+| Python | 3.11 | For the FastAPI backend and ingestion pipeline. |
+| PostgreSQL | any recent | Running and accessible. |
+| Disk space | ~2 GB | For the QVAC embedding model (~670 MB) downloaded on first run. |
+| RAM | ≥ 8 GB | For the default LLM when one is configured (see QVAC docs). |
 
 ### Recommended
 
@@ -31,21 +35,22 @@ chmod +x start-dev.sh
 
 This script creates a Python virtualenv under `services/ai/venv/`, installs dependencies for both services, seeds the database with test users, and starts both servers.
 
-| Service       | URL                                          |
-|---------------|----------------------------------------------|
-| Frontend      | <http://localhost:3000>                      |
-| Backend API   | <http://localhost:8000>                      |
-| Swagger UI    | <http://localhost:8000/docs>                 |
-| ReDoc         | <http://localhost:8000/redoc>                |
+| Service        | URL                        |
+|----------------|----------------------------|
+| Frontend       | <http://localhost:3000>    |
+| Backend API    | <http://localhost:8000>    |
+| QVAC service   | <http://localhost:3001>    |
+| Swagger UI     | <http://localhost:8000/docs>  |
+| ReDoc          | <http://localhost:8000/redoc> |
 
 > Swagger UI and ReDoc are only available in `development` environment.
 
 **Dev credentials (seeded automatically):**
 
-| Role    | Email                      | Password              |
-|---------|----------------------------|-----------------------|
-| Admin   | admin@bitpolito.it         | DevAdmin@2024!Secure  |
-| Student | student@bitpolito.it       | DevStudent@2024!Learn |
+| Role    | Email                | Password              |
+|---------|----------------------|-----------------------|
+| Admin   | admin@bitpolito.it   | DevAdmin@2024!Secure  |
+| Student | student@bitpolito.it | DevStudent@2024!Learn |
 
 ### Manual setup
 
@@ -66,6 +71,15 @@ pip install -r requirements.txt
 python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
+**QVAC service** (Node.js — embedding + retrieval + optional LLM generation):
+
+```bash
+cd workers/qvac-service
+npm install
+node src/server.js
+# Downloads the embedding model (~670 MB) on first run, then listens on :3001
+```
+
 ---
 
 ## Project Structure
@@ -80,30 +94,43 @@ bitcoin-academy/
 │           ├── components/         # React components
 │           └── lib/                # API client, auth helpers, services
 ├── services/
-│   └── ai/                         # FastAPI backend (primary service)
+│   └── ai/                         # FastAPI backend
 │       ├── Dockerfile
 │       └── app/
-│           ├── api/                # Route handlers (auth, courses, documents, progress)
-│           ├── workers/            # Document processing pipeline
-│           │   └── pipeline.py     # parse → chunk → embed → index (runs as BackgroundTask)
-│           ├── services/           # Business logic
+│           ├── api/                # Route handlers (auth, chat, courses, documents, progress, quizzes, certificates)
+│           ├── workers/
+│           │   └── pipeline.py     # parse → chunk → ChromaDB + QVAC ingest (BackgroundTask)
+│           ├── services/
+│           │   └── chat_service.py # Forwards /chat queries to the QVAC service via httpx
 │           ├── repositories/       # Data access layer
 │           ├── db/                 # SQLAlchemy models and session
-│           ├── rag/                # LangChain RAG pipeline (chains, retrievers, prompts)
 │           ├── schemas/            # Pydantic request/response models
 │           ├── core/               # Config, DI container, error handling, token blacklist
 │           └── middleware/         # Request ID, security headers
-├── workers/                        # Standalone pipeline script (reference / CLI testing)
-│   └── main.py
+├── workers/
+│   ├── python-ingester/            # Standalone Python ingestion pipeline (PDF/PPTX → JSONL)
+│   │   └── src/
+│   │       ├── module_1_ingestor.py   # RamSafeIngestor — RAM-safe PDF/PPTX batch reader
+│   │       ├── module_2_parser.py     # StructuralParser — hybrid pdfplumber + Docling ML
+│   │       ├── module_3_micro_chunker.py  # VerilocalChunker — 3-level chunking (section/paragraph/micro)
+│   │       ├── module_4_exporter.py   # JsonlExporter — writes *_contingency.jsonl
+│   │       ├── retrieval_*.py         # ChromaDB embedder + searcher + benchmark
+│   │       └── main_ingester_pipeline.py  # CLI entry point
+│   └── qvac-service/               # Node.js service — QVAC SDK (embedding + HyperDB + LLM)
+│       └── src/
+│           ├── models.js    # loadModel lifecycle (GTE_LARGE_FP16 embedding; LLM placeholder)
+│           ├── ingest.js    # ragIngest — reads *_contingency.jsonl, indexes paragraph chunks
+│           ├── query.js     # ragSearch + optional completion
+│           └── server.js    # HTTP server on :3001 — POST /ingest, POST /query, GET /health
 ├── docs/
-│   └── examples/
-│       └── prototype/              # Original in-memory API prototype (reference only)
+│   ├── qvac-integration.md         # Step-by-step guide for the QVAC SDK integration
+│   └── src/                        # Source PDFs and PPTX used in tests
 ├── .github/
 │   └── workflows/
 │       └── ci.yml                  # CI: pytest + mypy + tsc + jest on every PR
-├── docker-compose.yml              # Full stack: postgres + api + web
-├── start-dev.sh                    # Dev startup script (no Docker required)
-└── package.json                    # Root workspace (npm workspaces: apps/*, services/*)
+├── docker-compose.yml
+├── start-dev.sh
+└── package.json                    # Root workspace (npm workspaces: apps/*, workers/qvac-service)
 ```
 
 ---
@@ -112,26 +139,46 @@ bitcoin-academy/
 
 ### Frontend (`apps/web`)
 
-| Technology     | Role                          |
-|----------------|-------------------------------|
-| Next.js 14     | React framework, App Router   |
-| TypeScript     | Type safety                   |
-| Tailwind CSS   | Styling                       |
-| NextAuth.js 4  | Session-based authentication  |
-| Jest + RTL     | Unit and integration tests    |
+| Technology    | Role                         |
+|---------------|------------------------------|
+| Next.js 14    | React framework, App Router  |
+| TypeScript    | Type safety                  |
+| Tailwind CSS  | Styling                      |
+| NextAuth.js 4 | Session-based authentication |
+| Jest + RTL    | Unit and integration tests   |
 
 ### Backend (`services/ai`)
 
-| Technology          | Role                                    |
-|---------------------|-----------------------------------------|
-| FastAPI             | Async HTTP framework                    |
-| SQLAlchemy 2        | ORM                                     |
-| Pydantic v2         | Data validation and serialization       |
-| python-jose + bcrypt| JWT authentication                      |
-| LangChain + OpenAI  | RAG pipeline for AI tutoring            |
-| PostgreSQL          | Primary database                        |
-| slowapi             | Rate limiting                           |
-| pytest              | Test suite                              |
+| Technology           | Role                                          |
+|----------------------|-----------------------------------------------|
+| FastAPI              | HTTP framework                                |
+| SQLAlchemy 2         | ORM                                           |
+| Pydantic v2          | Data validation and serialization             |
+| python-jose + bcrypt | JWT authentication                            |
+| httpx                | HTTP client — calls the QVAC service for chat |
+| ChromaDB             | Vector store used during document ingestion   |
+| fastembed            | Embedding during ingestion (all-MiniLM-L6-v2) |
+| PostgreSQL           | Primary database                              |
+| slowapi              | Rate limiting                                 |
+| pytest               | Test suite                                    |
+
+### QVAC service (`workers/qvac-service`)
+
+| Technology    | Role                                                              |
+|---------------|-------------------------------------------------------------------|
+| Node.js 22.17+| Runtime                                                           |
+| `@qvac/sdk`   | Local-first AI — embedding, HyperDB vector store, LLM generation |
+| `node:test`   | Built-in test runner                                              |
+
+### Document ingestion pipeline (`workers/python-ingester`)
+
+| Technology         | Role                                              |
+|--------------------|---------------------------------------------------|
+| pdfplumber         | Primary PDF parser                                |
+| Docling | ML-based parser — flag `--docling`                |
+| python-pptx        | PPTX parser                                       |
+| fastembed          | Paragraph-level embedding (all-MiniLM-L6-v2 ONNX) |
+| ChromaDB           | Persistent vector store                           |
 
 ---
 
@@ -146,9 +193,34 @@ DATABASE_URL=postgresql://user:password@localhost:5432/bitcoin_academy
 SECRET_KEY=your-secret-key
 ENVIRONMENT=development
 CORS_ORIGINS=http://localhost:3000
+
+# QVAC service (default: http://localhost:3001)
+QVAC_SERVICE_URL=http://localhost:3001
+
+# Directory where the pipeline writes JSONL files for QVAC ingestion
+# (default: services/ai/qvac_ingest/)
+QVAC_INGEST_DIR=/absolute/path/to/qvac_ingest
+
+# ChromaDB path (default: services/ai/chroma_db/)
+CHROMA_DB_PATH=/absolute/path/to/chroma_db
 ```
 
-`DATABASE_URL` and `SECRET_KEY` are required at startup — the app will crash without them.
+`DATABASE_URL` and `SECRET_KEY` are required at startup.
+
+**QVAC service** — environment variables (optional):
+
+```env
+# Override the LLM model — any of the four modelSrc options in qvac-integration.md
+# Default: QWEN3_4B_INST_Q4_K_M from the QVAC registry (~2.4 GB, requires ≥ 8 GB RAM)
+# Leave unset to run without an LLM (embedding + retrieval only)
+QVAC_LLM_SRC=/path/to/local/model.gguf
+
+# Override the embedding model (default: GTE_LARGE_FP16, ~670 MB)
+QVAC_EMB_SRC=
+
+# Port (default: 3001)
+QVAC_PORT=3001
+```
 
 **Frontend** — create `apps/web/.env.local`:
 
@@ -175,27 +247,74 @@ npm run format           # Prettier
 
 ```bash
 cd services/ai
-mypy .                   # Type checking
-pytest                   # All tests
-pytest tests/unit -v     # Unit tests with coverage
-pytest tests/integration # Integration tests
+pytest                          # All tests (excludes slow)
+pytest tests/unit -v            # Unit tests
+pytest tests/integration        # Integration tests
+pytest -m slow                  # Pipeline e2e (requires fastembed + chromadb)
+mypy .
+```
+
+**QVAC service only:**
+
+```bash
+cd workers/qvac-service
+npm test                        # node:test unit suite (no model download)
+node src/server.js              # Start service — downloads models on first run
+```
+
+**Ingestion pipeline (CLI):**
+
+```bash
+cd workers/python-ingester
+# Index a document into both ChromaDB and QVAC (QVAC service must be running)
+python src/main_ingester_pipeline.py lecture.pdf \
+  --course-id BTC_2025 --lecture-id L01 --docling
+```
+
+### Document ingestion flow
+
+```
+Upload via API                   CLI (direct)
+       │                              │
+       ▼                              ▼
+pipeline.py (BackgroundTask)    main_ingester_pipeline.py
+  │
+  ├─ RamSafeIngestor + StructuralParser (PDF/PPTX → blocks)
+  ├─ VerilocalChunker (section / paragraph / micro)
+  ├─ fastembed + ChromaDB (paragraph chunks → vector store)
+  ├─ Write *_contingency.jsonl to QVAC_INGEST_DIR
+  └─ POST http://localhost:3001/ingest  ←── QVAC service
+                                              └─ ragIngest → HyperDB workspace
+```
+
+### Chat query flow
+
+```
+Student question
+  → POST /api/courses/{id}/chat  (FastAPI, JWT required)
+  → chat_service.py
+  → POST http://localhost:3001/query  (QVAC service)
+        └─ ragSearch (HyperDB) → optional LLM completion
+  → ChatResponse { answer, citations: [{snippet, score}], retrieval_used }
 ```
 
 ---
 
 ## API
 
-Registered routers in `services/ai/app/main.py`:
+All routers registered in `services/ai/app/main.py`:
 
-| Prefix       | Description                  |
-|--------------|------------------------------|
-| `/auth`      | Registration, login, JWT     |
-| `/courses`   | Course CRUD                  |
-| `/documents` | PDF upload and indexing      |
-| `/progress`  | User progress tracking       |
-| `/health`    | Health check with DB ping    |
+| Prefix                        | Description                         |
+|-------------------------------|-------------------------------------|
+| `/api/auth`                   | Registration, login, JWT refresh    |
+| `/api/courses/{id}/chat`      | RAG-backed Q&A (QVAC service)       |
+| `/api/courses`                | Course CRUD and lesson listing      |
+| `/api/courses/{id}/documents` | PDF/PPTX upload and indexing        |
+| `/api/users/me/...`           | Progress tracking and certificates  |
+| `/api/quizzes`                | Quiz placeholders (not yet active)  |
+| `/health`                     | Health check with DB ping           |
 
-> **Implemented but not yet registered:** `quizzes_api.py`, `chat_api.py`, `certificates_api.py` exist in `app/api/` but are not included in `app/main.py`.
+Full interactive reference: `http://localhost:8000/docs` (development only).
 
 ---
 
@@ -208,9 +327,10 @@ Registered routers in `services/ai/app/main.py`:
 
 **Guidelines:**
 
-- TypeScript for frontend, Python for backend
-- Run `npm run type-check` and `pytest` before opening a PR
-- Update this README if you change the project structure or add new routes
+- TypeScript for frontend, Python for backend, JavaScript (ESM) for the QVAC service
+- Run `npm run type-check`, `pytest`, and `npm test` (in `workers/qvac-service`) before opening a PR
+- Node.js ≥ 22.17 is required — earlier versions will fail on `import "@qvac/sdk"`
+- Update this README if you change the project structure, add new routes, or modify the startup sequence
 
 ---
 

--- a/apps/web/__tests__/integration/study-flow.test.tsx
+++ b/apps/web/__tests__/integration/study-flow.test.tsx
@@ -1,0 +1,416 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSession } from 'next-auth/react';
+import { useParams } from 'next/navigation';
+
+// scrollIntoView not implemented in jsdom
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
+}));
+
+jest.mock('@/lib/services/courses', () => ({
+  getCourse: jest.fn(),
+  getCourseLessons: jest.fn(),
+}));
+
+jest.mock('@/lib/services/progress', () => ({
+  getCourseProgress: jest.fn(),
+  markLessonComplete: jest.fn(),
+}));
+
+jest.mock('@/lib/services/documents', () => ({
+  getDocuments: jest.fn(),
+}));
+
+jest.mock('@/lib/api/documents', () => ({
+  getDocumentPreviewView: jest.fn(),
+}));
+
+jest.mock('@/lib/services/chat', () => ({
+  sendChatMessage: jest.fn(),
+}));
+
+// ── Imports after mocks ─────────────────────────────────────────────────────
+
+import { getCourse, getCourseLessons } from '@/lib/services/courses';
+import { getCourseProgress, markLessonComplete } from '@/lib/services/progress';
+import { getDocuments } from '@/lib/services/documents';
+import { getDocumentPreviewView } from '@/lib/api/documents';
+import { sendChatMessage } from '@/lib/services/chat';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const StudyPage = require('../../src/app/courses/[courseId]/study/page').default;
+
+// ── Shared fixtures ─────────────────────────────────────────────────────────
+
+const COURSE = { id: 'course-123', title: 'Bitcoin Fundamentals', description: 'Learn Bitcoin.' };
+const LESSONS = [
+  { id: 1, title: 'Introduction to Bitcoin', content: '' },
+  { id: 2, title: 'How Mining Works', content: 'Mining is the process...' },
+];
+const PROGRESS = {
+  courseId: 'course-123',
+  percent: 0,
+  status: 'not_started',
+  lessonCount: 2,
+  completedCount: 0,
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+function setupMocks() {
+  (useSession as jest.Mock).mockReturnValue({
+    data: { user: { accessToken: 'test-token' } },
+    status: 'authenticated',
+  });
+  (useParams as jest.Mock).mockReturnValue({ courseId: 'course-123' });
+  (getCourse as jest.Mock).mockResolvedValue(COURSE);
+  (getCourseLessons as jest.Mock).mockResolvedValue(LESSONS);
+  (getCourseProgress as jest.Mock).mockResolvedValue(PROGRESS);
+  (getDocuments as jest.Mock).mockResolvedValue([]);
+  (getDocumentPreviewView as jest.Mock).mockResolvedValue({
+    id: 'doc-1',
+    filename: 'guide.pdf',
+    extractedTextPreview: null,
+    pageCount: null,
+    sections: [],
+    sampleChunks: [],
+  });
+}
+
+describe('Study Flow Integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+  });
+
+  describe('initial load', () => {
+    it('shows course title after data loads', async () => {
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Bitcoin Fundamentals')).toBeInTheDocument();
+      });
+    });
+
+    it('renders all lesson titles in the sidebar', async () => {
+      render(<StudyPage />);
+
+      // First lesson title appears in both the nav and the content header (auto-selected)
+      await waitFor(() => {
+        expect(screen.getAllByText('Introduction to Bitcoin').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getByText('How Mining Works')).toBeInTheDocument();
+      });
+    });
+
+    it('selects the first lesson by default', async () => {
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        const buttons = screen.getAllByRole('button').filter((b) =>
+          b.textContent?.includes('Introduction to Bitcoin')
+        );
+        expect(buttons[0]).toHaveAttribute('aria-current', 'true');
+      });
+    });
+
+    it('shows a loading spinner during fetch', () => {
+      // Make getCourse never resolve
+      (getCourse as jest.Mock).mockImplementation(() => new Promise(() => {}));
+      render(<StudyPage />);
+      // A loading spinner should be visible
+      expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+    });
+
+    it('shows course progress bar when progress is loaded', async () => {
+      (getCourseProgress as jest.Mock).mockResolvedValue({
+        ...PROGRESS,
+        percent: 50,
+        completedCount: 1,
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('lesson selection', () => {
+    it('updates the selected lesson when clicking a different lesson', async () => {
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('How Mining Works')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('How Mining Works'));
+
+      await waitFor(() => {
+        const buttons = screen.getAllByRole('button').filter((b) =>
+          b.textContent?.includes('How Mining Works')
+        );
+        expect(buttons[0]).toHaveAttribute('aria-current', 'true');
+      });
+    });
+
+    it('shows lesson content when a lesson with content is selected', async () => {
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('How Mining Works')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('How Mining Works'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Mining is the process...')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('content chunks display', () => {
+    it('shows document chunks when course has ready documents', async () => {
+      (getDocuments as jest.Mock).mockResolvedValue([
+        { id: 'doc-1', filename: 'bitcoin-guide.pdf', status: 'ready', size: 1024, created_at: '' },
+      ]);
+      (getDocumentPreviewView as jest.Mock).mockResolvedValue({
+        id: 'doc-1',
+        filename: 'bitcoin-guide.pdf',
+        extractedTextPreview: null,
+        pageCount: 5,
+        sections: [{ title: 'What is Bitcoin?' }],
+        sampleChunks: [
+          { text: 'Bitcoin is a decentralized digital currency.', section: 'What is Bitcoin?' },
+          { text: 'Transactions are verified by network nodes.', section: 'What is Bitcoin?' },
+        ],
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Course Material')).toBeInTheDocument();
+        expect(screen.getByText('bitcoin-guide.pdf')).toBeInTheDocument();
+        expect(
+          screen.getByText('Bitcoin is a decentralized digital currency.')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows section chips for document sections', async () => {
+      (getDocuments as jest.Mock).mockResolvedValue([
+        { id: 'doc-1', filename: 'guide.pdf', status: 'ready', size: 512, created_at: '' },
+      ]);
+      (getDocumentPreviewView as jest.Mock).mockResolvedValue({
+        id: 'doc-1',
+        filename: 'guide.pdf',
+        extractedTextPreview: null,
+        pageCount: 2,
+        sections: [{ title: 'Overview' }, { title: 'Key Concepts' }],
+        sampleChunks: [{ text: 'Some chunk text.' }],
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Overview')).toBeInTheDocument();
+        expect(screen.getByText('Key Concepts')).toBeInTheDocument();
+      });
+    });
+
+    it('shows no Course Material section when no ready documents exist', async () => {
+      (getDocuments as jest.Mock).mockResolvedValue([
+        { id: 'doc-1', filename: 'pending.pdf', status: 'processing', size: 512, created_at: '' },
+      ]);
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Course Material')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('chat integration', () => {
+    it('sends a message to the chat service with correct courseId', async () => {
+      (sendChatMessage as jest.Mock).mockResolvedValue({
+        answer: 'Bitcoin was created in 2009.',
+        citations: [],
+        retrievalUsed: false,
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /message input/i })).toBeInTheDocument();
+      });
+
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'When was Bitcoin created?');
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      await waitFor(() => {
+        expect(sendChatMessage).toHaveBeenCalledWith(
+          'course-123',
+          'When was Bitcoin created?',
+          'test-token'
+        );
+      });
+    });
+
+    it('displays the AI response in the chat thread', async () => {
+      (sendChatMessage as jest.Mock).mockResolvedValue({
+        answer: 'Satoshi Nakamoto created Bitcoin.',
+        citations: [],
+        retrievalUsed: false,
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /message input/i })).toBeInTheDocument();
+      });
+
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'Who created Bitcoin?');
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Satoshi Nakamoto created Bitcoin.')).toBeInTheDocument();
+      });
+    });
+
+    it('shows citations returned with the AI response', async () => {
+      (sendChatMessage as jest.Mock).mockResolvedValue({
+        answer: 'Bitcoin uses proof of work.',
+        citations: [{ snippet: 'Proof of work is the consensus mechanism.', score: 0.88 }],
+        retrievalUsed: true,
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /message input/i })).toBeInTheDocument();
+      });
+
+      await userEvent.type(
+        screen.getByRole('textbox', { name: /message input/i }),
+        'How does consensus work?'
+      );
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/proof of work is the consensus mechanism/i)).toBeInTheDocument();
+        expect(screen.getByText('Relevance: 88%')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('lesson completion', () => {
+    it('calls markLessonComplete with correct lessonId and courseId', async () => {
+      (markLessonComplete as jest.Mock).mockResolvedValue({
+        lessonProgress: { lessonId: '1', status: 'completed', lastScore: null },
+        courseProgress: { ...PROGRESS, percent: 50, completedCount: 1 },
+        newBadges: [],
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /mark as complete/i })).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /mark as complete/i }));
+
+      await waitFor(() => {
+        expect(markLessonComplete).toHaveBeenCalledWith('1', 'course-123', 'test-token');
+      });
+    });
+
+    it('shows "Lesson completed" after marking complete', async () => {
+      (markLessonComplete as jest.Mock).mockResolvedValue({
+        lessonProgress: { lessonId: '1', status: 'completed', lastScore: null },
+        courseProgress: { ...PROGRESS, percent: 50, completedCount: 1 },
+        newBadges: [],
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /mark as complete/i })).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /mark as complete/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Lesson completed')).toBeInTheDocument();
+      });
+    });
+
+    it('shows a badge notification when a new badge is earned', async () => {
+      (markLessonComplete as jest.Mock).mockResolvedValue({
+        lessonProgress: { lessonId: '1', status: 'completed', lastScore: null },
+        courseProgress: { ...PROGRESS, percent: 50, completedCount: 1 },
+        newBadges: [
+          {
+            id: 'badge-1',
+            slug: 'first-lesson',
+            name: 'First Steps',
+            description: 'Completed your first lesson',
+            icon: '🎯',
+          },
+        ],
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /mark as complete/i })).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /mark as complete/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/new badge earned/i)).toBeInTheDocument();
+        expect(screen.getByText('First Steps')).toBeInTheDocument();
+      });
+    });
+
+    it('updates progress bar percentage after marking complete', async () => {
+      (markLessonComplete as jest.Mock).mockResolvedValue({
+        lessonProgress: { lessonId: '1', status: 'completed', lastScore: null },
+        courseProgress: { ...PROGRESS, percent: 50, completedCount: 1 },
+        newBadges: [],
+      });
+      (getCourseProgress as jest.Mock).mockResolvedValue({
+        ...PROGRESS,
+        percent: 0,
+        completedCount: 0,
+      });
+
+      render(<StudyPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /mark as complete/i })).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /mark as complete/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '50');
+      });
+    });
+  });
+});

--- a/apps/web/__tests__/unit/LessonNav.test.tsx
+++ b/apps/web/__tests__/unit/LessonNav.test.tsx
@@ -1,0 +1,152 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LessonNav } from '../../src/components/study/LessonNav';
+import type { Lesson } from '../../src/lib/services/courses';
+
+const LESSONS: Lesson[] = [
+  { id: 1, title: 'Introduction to Bitcoin' },
+  { id: 2, title: 'How Mining Works' },
+  { id: 3, title: 'Lightning Network' },
+];
+
+describe('LessonNav', () => {
+  const noop = () => {};
+
+  describe('rendering', () => {
+    it('renders all lesson titles', () => {
+      render(
+        <LessonNav
+          lessons={LESSONS}
+          selectedLesson={null}
+          completedLessons={new Set()}
+          onSelect={noop}
+        />
+      );
+
+      expect(screen.getByText('Introduction to Bitcoin')).toBeInTheDocument();
+      expect(screen.getByText('How Mining Works')).toBeInTheDocument();
+      expect(screen.getByText('Lightning Network')).toBeInTheDocument();
+    });
+
+    it('renders 1-based ordinal numbers for each lesson', () => {
+      render(
+        <LessonNav
+          lessons={LESSONS}
+          selectedLesson={null}
+          completedLessons={new Set()}
+          onSelect={noop}
+        />
+      );
+
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('shows empty state when lessons array is empty', () => {
+      render(
+        <LessonNav
+          lessons={[]}
+          selectedLesson={null}
+          completedLessons={new Set()}
+          onSelect={noop}
+        />
+      );
+
+      expect(screen.getByText(/no lessons available/i)).toBeInTheDocument();
+    });
+
+    it('shows loading skeleton when loading is true', () => {
+      const { container } = render(
+        <LessonNav
+          lessons={LESSONS}
+          selectedLesson={null}
+          completedLessons={new Set()}
+          onSelect={noop}
+          loading
+        />
+      );
+
+      // Skeleton divs are present; lesson titles are not rendered
+      expect(screen.queryByText('Introduction to Bitcoin')).not.toBeInTheDocument();
+      expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('selection', () => {
+    it('marks the selected lesson with aria-current', () => {
+      render(
+        <LessonNav
+          lessons={LESSONS}
+          selectedLesson={LESSONS[1]}
+          completedLessons={new Set()}
+          onSelect={noop}
+        />
+      );
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons[1]).toHaveAttribute('aria-current', 'true');
+      expect(buttons[0]).not.toHaveAttribute('aria-current');
+    });
+
+    it('calls onSelect with the clicked lesson', () => {
+      const onSelect = jest.fn();
+      render(
+        <LessonNav
+          lessons={LESSONS}
+          selectedLesson={null}
+          completedLessons={new Set()}
+          onSelect={onSelect}
+        />
+      );
+
+      fireEvent.click(screen.getByText('How Mining Works'));
+      expect(onSelect).toHaveBeenCalledWith(LESSONS[1]);
+    });
+  });
+
+  describe('completion state', () => {
+    it('shows "Done" label for completed lessons', () => {
+      render(
+        <LessonNav
+          lessons={LESSONS}
+          selectedLesson={null}
+          completedLessons={new Set(['1', '3'])}
+          onSelect={noop}
+        />
+      );
+
+      // Two lessons are done
+      expect(screen.getAllByText('Done')).toHaveLength(2);
+    });
+
+    it('does not show "Done" for incomplete lessons', () => {
+      render(
+        <LessonNav
+          lessons={LESSONS}
+          selectedLesson={null}
+          completedLessons={new Set(['1'])}
+          onSelect={noop}
+        />
+      );
+
+      expect(screen.getAllByText('Done')).toHaveLength(1);
+    });
+
+    it('hides the ordinal number for completed lessons (replaced by checkmark)', () => {
+      render(
+        <LessonNav
+          lessons={LESSONS}
+          selectedLesson={null}
+          completedLessons={new Set(['1'])}
+          onSelect={noop}
+        />
+      );
+
+      // Lesson 1 is complete: no "1" badge visible, but "2" and "3" are
+      expect(screen.queryByText('1')).not.toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/__tests__/unit/OutputPane.test.tsx
+++ b/apps/web/__tests__/unit/OutputPane.test.tsx
@@ -1,0 +1,234 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OutputPane } from '../../src/components/study/OutputPane';
+
+// scrollIntoView is not implemented in jsdom
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+
+// Mock the chat service so no real HTTP calls are made
+jest.mock('../../src/lib/services/chat', () => ({
+  sendChatMessage: jest.fn(),
+}));
+
+import { sendChatMessage } from '../../src/lib/services/chat';
+const mockSend = sendChatMessage as jest.MockedFunction<typeof sendChatMessage>;
+
+describe('OutputPane', () => {
+  const defaultProps = { courseId: 'course-123', accessToken: 'tok' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initial render', () => {
+    it('renders the AI Tutor heading', () => {
+      render(<OutputPane {...defaultProps} />);
+      expect(screen.getByText('AI Tutor')).toBeInTheDocument();
+    });
+
+    it('renders the message input area', () => {
+      render(<OutputPane {...defaultProps} />);
+      expect(screen.getByRole('textbox', { name: /message input/i })).toBeInTheDocument();
+    });
+
+    it('renders the send button', () => {
+      render(<OutputPane {...defaultProps} />);
+      expect(screen.getByRole('button', { name: /send message/i })).toBeInTheDocument();
+    });
+
+    it('disables send button when input is empty', () => {
+      render(<OutputPane {...defaultProps} />);
+      expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled();
+    });
+
+    it('shows the empty-state prompt when no messages', () => {
+      render(<OutputPane {...defaultProps} />);
+      expect(screen.getByText(/ask me anything/i)).toBeInTheDocument();
+    });
+
+    it('shows lesson-specific placeholder when a lesson is selected', () => {
+      render(
+        <OutputPane
+          {...defaultProps}
+          selectedLesson={{ id: 1, title: 'How Mining Works' }}
+        />
+      );
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      expect(textarea).toHaveAttribute('placeholder', 'Ask about "How Mining Works"…');
+    });
+  });
+
+  describe('sending a message', () => {
+    it('enables send button when input has text', async () => {
+      render(<OutputPane {...defaultProps} />);
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'What is a UTXO?');
+      expect(screen.getByRole('button', { name: /send message/i })).not.toBeDisabled();
+    });
+
+    it('shows user message in the thread after send', async () => {
+      mockSend.mockResolvedValue({ answer: 'A UTXO is an unspent output.', citations: [], retrievalUsed: false });
+
+      render(<OutputPane {...defaultProps} />);
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'What is a UTXO?');
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      expect(screen.getByText('What is a UTXO?')).toBeInTheDocument();
+    });
+
+    it('clears the input after send', async () => {
+      mockSend.mockResolvedValue({ answer: 'Answer.', citations: [], retrievalUsed: false });
+
+      render(<OutputPane {...defaultProps} />);
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'Hello');
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      expect(textarea).toHaveValue('');
+    });
+
+    it('shows loading dots while waiting for response', async () => {
+      mockSend.mockImplementation(() => new Promise(() => {})); // never resolves
+
+      render(<OutputPane {...defaultProps} />);
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'Question?');
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      expect(screen.getByLabelText(/loading response/i)).toBeInTheDocument();
+    });
+
+    it('shows assistant reply after response arrives', async () => {
+      mockSend.mockResolvedValue({
+        answer: 'Bitcoin is a peer-to-peer currency.',
+        citations: [],
+        retrievalUsed: false,
+      });
+
+      render(<OutputPane {...defaultProps} />);
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'What is Bitcoin?');
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Bitcoin is a peer-to-peer currency.')).toBeInTheDocument();
+      });
+    });
+
+    it('sends via Enter key (without Shift)', async () => {
+      mockSend.mockResolvedValue({ answer: 'Answer.', citations: [], retrievalUsed: false });
+
+      render(<OutputPane {...defaultProps} />);
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'Question?{Enter}');
+
+      expect(mockSend).toHaveBeenCalledWith('course-123', 'Question?', 'tok');
+    });
+
+    it('calls sendChatMessage with correct courseId and accessToken', async () => {
+      mockSend.mockResolvedValue({ answer: 'Ok.', citations: [], retrievalUsed: false });
+
+      render(<OutputPane courseId="my-course" accessToken="my-token" />);
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'Test question');
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      expect(mockSend).toHaveBeenCalledWith('my-course', 'Test question', 'my-token');
+    });
+  });
+
+  describe('citations', () => {
+    it('renders citation snippets when the response includes sources', async () => {
+      mockSend.mockResolvedValue({
+        answer: 'Answer with sources.',
+        citations: [
+          { snippet: 'The first source text.', score: 0.95 },
+          { snippet: 'The second source text.', score: 0.80 },
+        ],
+        retrievalUsed: true,
+      });
+
+      render(<OutputPane {...defaultProps} />);
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'Question?');
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/the first source text/i)).toBeInTheDocument();
+        expect(screen.getByText(/the second source text/i)).toBeInTheDocument();
+      });
+    });
+
+    it('shows relevance percentage for each citation', async () => {
+      mockSend.mockResolvedValue({
+        answer: 'Answer.',
+        citations: [{ snippet: 'Snippet.', score: 0.92 }],
+        retrievalUsed: true,
+      });
+
+      render(<OutputPane {...defaultProps} />);
+      await userEvent.type(
+        screen.getByRole('textbox', { name: /message input/i }),
+        'Question?'
+      );
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Relevance: 92%')).toBeInTheDocument();
+      });
+    });
+
+    it('shows "Sources" heading when citations are present', async () => {
+      mockSend.mockResolvedValue({
+        answer: 'Answer.',
+        citations: [{ snippet: 'Source.', score: 0.9 }],
+        retrievalUsed: true,
+      });
+
+      render(<OutputPane {...defaultProps} />);
+      await userEvent.type(
+        screen.getByRole('textbox', { name: /message input/i }),
+        'Q?'
+      );
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Sources')).toBeInTheDocument();
+      });
+    });
+
+    it('does not render Sources section when citations array is empty', async () => {
+      mockSend.mockResolvedValue({ answer: 'No sources.', citations: [], retrievalUsed: false });
+
+      render(<OutputPane {...defaultProps} />);
+      await userEvent.type(
+        screen.getByRole('textbox', { name: /message input/i }),
+        'Q?'
+      );
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Sources')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('shows an error message in the thread when the API call fails', async () => {
+      mockSend.mockRejectedValue(new Error('Network error'));
+
+      render(<OutputPane {...defaultProps} />);
+      const textarea = screen.getByRole('textbox', { name: /message input/i });
+      await userEvent.type(textarea, 'Question?');
+      fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/network error/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/web/__tests__/unit/ProgressBar.test.tsx
+++ b/apps/web/__tests__/unit/ProgressBar.test.tsx
@@ -1,0 +1,83 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ProgressBar } from '../../src/components/ui/ProgressBar';
+
+describe('ProgressBar', () => {
+  describe('rendering', () => {
+    it('renders a progressbar role element', () => {
+      render(<ProgressBar percent={50} />);
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('shows the percentage label when showPercent is true (default)', () => {
+      render(<ProgressBar percent={42} />);
+      expect(screen.getByText('42%')).toBeInTheDocument();
+    });
+
+    it('hides the percentage label when showPercent is false', () => {
+      render(<ProgressBar percent={42} showPercent={false} />);
+      expect(screen.queryByText('42%')).not.toBeInTheDocument();
+    });
+
+    it('renders a custom label', () => {
+      render(<ProgressBar percent={30} label="3 of 10 lessons completed" />);
+      expect(screen.getByText('3 of 10 lessons completed')).toBeInTheDocument();
+    });
+
+    it('sets correct aria-valuenow', () => {
+      render(<ProgressBar percent={75} />);
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '75');
+    });
+
+    it('sets aria-valuemin to 0 and aria-valuemax to 100', () => {
+      render(<ProgressBar percent={50} />);
+      const bar = screen.getByRole('progressbar');
+      expect(bar).toHaveAttribute('aria-valuemin', '0');
+      expect(bar).toHaveAttribute('aria-valuemax', '100');
+    });
+  });
+
+  describe('value clamping', () => {
+    it('clamps values above 100 to 100', () => {
+      render(<ProgressBar percent={150} />);
+      expect(screen.getByText('100%')).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+    });
+
+    it('clamps negative values to 0', () => {
+      render(<ProgressBar percent={-20} />);
+      expect(screen.getByText('0%')).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('handles 0 correctly', () => {
+      render(<ProgressBar percent={0} />);
+      expect(screen.getByText('0%')).toBeInTheDocument();
+    });
+
+    it('handles 100 correctly', () => {
+      render(<ProgressBar percent={100} />);
+      expect(screen.getByText('100%')).toBeInTheDocument();
+    });
+  });
+
+  describe('bar width', () => {
+    it('sets the inner bar width to the given percent', () => {
+      const { container } = render(<ProgressBar percent={60} />);
+      const inner = container.querySelector('[style]') as HTMLElement;
+      expect(inner?.style.width).toBe('60%');
+    });
+
+    it('uses green color at 100%', () => {
+      const { container } = render(<ProgressBar percent={100} />);
+      const inner = container.querySelector('[style]') as HTMLElement;
+      expect(inner?.className).toContain('bg-green-500');
+    });
+
+    it('uses orange color below 100%', () => {
+      const { container } = render(<ProgressBar percent={50} />);
+      const inner = container.querySelector('[style]') as HTMLElement;
+      expect(inner?.className).toContain('bg-orange-500');
+    });
+  });
+});

--- a/apps/web/src/app/courses/[courseId]/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/page.tsx
@@ -6,6 +6,7 @@ import { useSession } from 'next-auth/react';
 import { getCourse, getCourseLessons, type Course, type Lesson } from '@/lib/services/courses';
 import { DocumentList } from '@/components/courses/DocumentList';
 import { DocumentUpload } from '@/components/documents/DocumentUpload';
+import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
 
 export default function CourseWorkspacePage() {
   const params = useParams();
@@ -135,11 +136,13 @@ export default function CourseWorkspacePage() {
               <h2 className="text-lg font-semibold text-gray-900">Documents</h2>
             </div>
             <div className="p-6">
-              <DocumentUpload
-                courseId={courseId}
-                accessToken={accessToken}
-                onUploadComplete={refreshDocuments}
-              />
+              <ErrorBoundary>
+                <DocumentUpload
+                  courseId={courseId}
+                  accessToken={accessToken}
+                  onUploadComplete={refreshDocuments}
+                />
+              </ErrorBoundary>
               <div className="mt-4">
                 <DocumentList
                   courseId={courseId}

--- a/apps/web/src/app/courses/[courseId]/study/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/study/page.tsx
@@ -15,6 +15,7 @@ import { SourcePane } from '@/components/study/SourcePane';
 import { OutputPane } from '@/components/study/OutputPane';
 import { ProgressBar } from '@/components/ui/ProgressBar';
 import { BadgeDisplay } from '@/components/ui/BadgeDisplay';
+import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
 
 export default function StudyPage() {
   const params = useParams();
@@ -52,6 +53,9 @@ export default function StudyPage() {
       try {
         const progress = await getCourseProgress(courseId, accessToken);
         setCourseProgress(progress);
+        if (progress.completedLessonIds.length > 0) {
+          setCompletedLessons(new Set(progress.completedLessonIds));
+        }
       } catch {
         // progress is non-critical
       }
@@ -133,11 +137,13 @@ export default function StudyPage() {
             />
           }
           right={
-            <OutputPane
-              courseId={courseId}
-              accessToken={accessToken}
-              selectedLesson={selectedLesson}
-            />
+            <ErrorBoundary>
+              <OutputPane
+                courseId={courseId}
+                accessToken={accessToken}
+                selectedLesson={selectedLesson}
+              />
+            </ErrorBoundary>
           }
           defaultLeftPercent={40}
         />

--- a/apps/web/src/app/courses/[courseId]/study/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/study/page.tsx
@@ -122,6 +122,8 @@ export default function StudyPage() {
         <SplitPane
           left={
             <SourcePane
+              courseId={courseId}
+              accessToken={accessToken}
               courseTitle={course?.title}
               lessons={lessons}
               selectedLesson={selectedLesson}

--- a/apps/web/src/app/courses/[courseId]/study/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/study/page.tsx
@@ -1,12 +1,20 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { getCourse, type Course } from '@/lib/services/courses';
+import { getCourse, getCourseLessons, type Course, type Lesson } from '@/lib/services/courses';
+import {
+  getCourseProgress,
+  markLessonComplete,
+  type Badge,
+  type CourseProgress,
+} from '@/lib/services/progress';
 import { SplitPane } from '@/components/study/SplitPane';
 import { SourcePane } from '@/components/study/SourcePane';
 import { OutputPane } from '@/components/study/OutputPane';
+import { ProgressBar } from '@/components/ui/ProgressBar';
+import { BadgeDisplay } from '@/components/ui/BadgeDisplay';
 
 export default function StudyPage() {
   const params = useParams();
@@ -15,21 +23,64 @@ export default function StudyPage() {
   const accessToken = (session?.user as any)?.accessToken;
 
   const [course, setCourse] = useState<Course | null>(null);
+  const [lessons, setLessons] = useState<Lesson[]>([]);
+  const [selectedLesson, setSelectedLesson] = useState<Lesson | null>(null);
+  const [completedLessons, setCompletedLessons] = useState<Set<string>>(new Set());
+  const [courseProgress, setCourseProgress] = useState<CourseProgress | null>(null);
+  const [newBadges, setNewBadges] = useState<Badge[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function load() {
       try {
-        const data = await getCourse(courseId, accessToken);
-        setCourse(data);
+        const [courseData, lessonsData] = await Promise.all([
+          getCourse(courseId, accessToken),
+          getCourseLessons(courseId, accessToken),
+        ]);
+        setCourse(courseData);
+        setLessons(lessonsData);
+        if (lessonsData.length > 0) setSelectedLesson(lessonsData[0]);
       } catch {
-        // Course info is optional for the layout
+        // empty state shown in SourcePane
       } finally {
         setLoading(false);
       }
     }
-    if (courseId) load();
+
+    async function loadProgress() {
+      if (!accessToken) return;
+      try {
+        const progress = await getCourseProgress(courseId, accessToken);
+        setCourseProgress(progress);
+      } catch {
+        // progress is non-critical
+      }
+    }
+
+    if (courseId) {
+      load();
+      loadProgress();
+    }
   }, [courseId, accessToken]);
+
+  const handleMarkComplete = useCallback(
+    async (lesson: Lesson) => {
+      if (!accessToken) return;
+      const lessonId = String(lesson.id);
+      try {
+        const result = await markLessonComplete(lessonId, courseId, accessToken);
+        setCompletedLessons((prev) => new Set([...prev, lessonId]));
+        setCourseProgress(result.courseProgress);
+        if (result.newBadges.length > 0) {
+          setNewBadges(result.newBadges);
+          setTimeout(() => setNewBadges([]), 5000);
+        }
+      } catch {
+        // non-critical; UI stays responsive
+      }
+    },
+    [courseId, accessToken]
+  );
 
   if (loading) {
     return (
@@ -40,12 +91,55 @@ export default function StudyPage() {
   }
 
   return (
-    <div className="h-[calc(100vh-7rem)]">
-      <SplitPane
-        left={<SourcePane courseTitle={course?.title} />}
-        right={<OutputPane />}
-        defaultLeftPercent={50}
-      />
+    <div className="flex flex-col h-[calc(100vh-7rem)]">
+      {/* Course progress strip */}
+      {courseProgress && (
+        <div className="flex-shrink-0 px-6 py-2 bg-white border-b border-gray-100">
+          <ProgressBar
+            percent={courseProgress.percent}
+            label={`${courseProgress.completedCount} of ${courseProgress.lessonCount} lessons completed`}
+            size="sm"
+          />
+        </div>
+      )}
+
+      {/* Badge notification — auto-dismisses after 5 s */}
+      {newBadges.length > 0 && (
+        <div className="flex-shrink-0 flex items-center gap-3 px-6 py-3 bg-yellow-50 border-b border-yellow-200">
+          <span className="text-sm font-medium text-yellow-800">
+            {newBadges.length === 1 ? 'New badge earned!' : 'New badges earned!'}
+          </span>
+          <div className="flex gap-2">
+            {newBadges.map((badge) => (
+              <BadgeDisplay key={badge.id} badge={badge} size="sm" />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Split pane — fills remaining height */}
+      <div className="flex-1 overflow-hidden">
+        <SplitPane
+          left={
+            <SourcePane
+              courseTitle={course?.title}
+              lessons={lessons}
+              selectedLesson={selectedLesson}
+              completedLessons={completedLessons}
+              onSelectLesson={setSelectedLesson}
+              onMarkComplete={handleMarkComplete}
+            />
+          }
+          right={
+            <OutputPane
+              courseId={courseId}
+              accessToken={accessToken}
+              selectedLesson={selectedLesson}
+            />
+          }
+          defaultLeftPercent={40}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/courses/page.tsx
+++ b/apps/web/src/app/courses/page.tsx
@@ -5,12 +5,14 @@ import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { getCourses, type Course } from '@/lib/services/courses';
+import { getCourseProgress } from '@/lib/services/progress';
 import { CourseCard } from '@/components/courses/CourseCard';
 
 export default function CoursesPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
   const [courses, setCourses] = useState<Course[]>([]);
+  const [progress, setProgress] = useState<Record<string | number, number>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -21,10 +23,22 @@ export default function CoursesPage() {
     }
     if (status !== 'authenticated') return;
 
-    async function fetchCourses() {
+    const token = (session?.user as any)?.accessToken;
+
+    async function fetchAll() {
       try {
-        const data = await getCourses(0, 100, (session?.user as any)?.accessToken);
+        const data = await getCourses(0, 100, token);
         setCourses(data);
+
+        // Fetch progress for all courses in parallel; failures are non-critical
+        const results = await Promise.allSettled(
+          data.map((c) => getCourseProgress(String(c.id), token))
+        );
+        const map: Record<string | number, number> = {};
+        results.forEach((r, i) => {
+          if (r.status === 'fulfilled') map[data[i].id] = r.value.percent;
+        });
+        setProgress(map);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load courses');
       } finally {
@@ -32,7 +46,7 @@ export default function CoursesPage() {
       }
     }
 
-    fetchCourses();
+    fetchAll();
   }, [status, session, router]);
 
   if (status === 'loading' || (status === 'authenticated' && loading)) {
@@ -50,7 +64,7 @@ export default function CoursesPage() {
                 <div className="h-5 w-3/4 bg-gray-200 rounded" />
                 <div className="mt-3 h-4 w-full bg-gray-100 rounded" />
                 <div className="mt-1 h-4 w-2/3 bg-gray-100 rounded" />
-                <div className="mt-5 h-4 w-1/3 bg-orange-100 rounded" />
+                <div className="mt-5 h-1.5 w-full bg-gray-100 rounded-full" />
               </div>
             ))}
           </div>
@@ -85,16 +99,32 @@ export default function CoursesPage() {
           </div>
         ) : courses.length === 0 ? (
           <div className="text-center py-16">
-            <svg className="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+            <svg
+              className="mx-auto h-12 w-12 text-gray-300"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+              />
             </svg>
             <h3 className="mt-4 text-lg font-medium text-gray-900">No courses available</h3>
-            <p className="mt-1 text-sm text-gray-500">Courses will appear here once they are created.</p>
+            <p className="mt-1 text-sm text-gray-500">
+              Courses will appear here once they are created.
+            </p>
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {courses.map((course) => (
-              <CourseCard key={course.id} course={course} />
+              <CourseCard
+                key={course.id}
+                course={course}
+                progress={progress[course.id] ?? null}
+              />
             ))}
           </div>
         )}

--- a/apps/web/src/components/courses/CourseCard.tsx
+++ b/apps/web/src/components/courses/CourseCard.tsx
@@ -2,12 +2,21 @@
 
 import Link from 'next/link';
 import type { Course } from '@/lib/services/courses';
+import { ProgressBar } from '@/components/ui/ProgressBar';
 
 interface CourseCardProps {
   course: Course;
+  progress?: number | null;
 }
 
-export function CourseCard({ course }: CourseCardProps) {
+export function CourseCard({ course, progress = null }: CourseCardProps) {
+  const ctaLabel =
+    progress === 100
+      ? 'Review course'
+      : progress != null && progress > 0
+      ? 'Continue studying'
+      : 'Start studying';
+
   return (
     <Link
       href={`/courses/${course.id}`}
@@ -27,15 +36,41 @@ export function CourseCard({ course }: CourseCardProps) {
           </div>
           <div className="ml-4 flex-shrink-0">
             <span className="inline-flex items-center justify-center h-10 w-10 rounded-lg bg-orange-100 text-orange-600">
-              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+              <svg
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+                />
               </svg>
             </span>
           </div>
         </div>
-        <div className="mt-4 flex items-center text-sm text-orange-600 font-medium">
-          Open workspace
-          <svg className="ml-1 h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+
+        {/* Progress indicator */}
+        <div className="mt-4">
+          {progress !== null ? (
+            <ProgressBar percent={progress} size="sm" />
+          ) : (
+            <div className="h-1.5 w-full bg-gray-100 rounded-full animate-pulse" />
+          )}
+        </div>
+
+        <div className="mt-3 flex items-center text-sm text-orange-600 font-medium">
+          {ctaLabel}
+          <svg
+            className="ml-1 h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
             <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
           </svg>
         </div>

--- a/apps/web/src/components/study/ContentChunks.tsx
+++ b/apps/web/src/components/study/ContentChunks.tsx
@@ -47,17 +47,17 @@ export function ContentChunks({ courseId, accessToken, className }: ContentChunk
             return {
               documentId: doc.id,
               filename: doc.filename,
-              sections: (preview.sections ?? []) as Section[],
-              chunks: (preview.sampleChunks ?? []) as Chunk[],
+              sections: (preview.sections ?? []).map((title) => ({ title })),
+              chunks: (preview.sampleChunks ?? []).map((c) => ({
+                text: c.text,
+                section: c.section ?? undefined,
+              })),
             };
           })
         );
 
         const loaded = previews
-          .filter(
-            (r): r is PromiseFulfilledResult<DocumentContent> => r.status === 'fulfilled'
-          )
-          .map((r) => r.value)
+          .flatMap((r) => (r.status === 'fulfilled' ? [r.value] : []))
           .filter((d) => d.chunks.length > 0 || d.sections.length > 0);
 
         setContents(loaded);

--- a/apps/web/src/components/study/ContentChunks.tsx
+++ b/apps/web/src/components/study/ContentChunks.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getDocuments } from '@/lib/services/documents';
+import { getDocumentPreviewView } from '@/lib/api/documents';
+
+// Typed shapes for document preview data returned by the backend
+interface Section {
+  title?: string;
+  level?: number;
+  page?: number;
+}
+
+interface Chunk {
+  text: string;
+  section?: string;
+  page?: number;
+}
+
+interface DocumentContent {
+  documentId: string;
+  filename: string;
+  sections: Section[];
+  chunks: Chunk[];
+}
+
+interface ContentChunksProps {
+  courseId: string;
+  accessToken?: string;
+  className?: string;
+}
+
+export function ContentChunks({ courseId, accessToken, className }: ContentChunksProps) {
+  const [contents, setContents] = useState<DocumentContent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchContent() {
+      try {
+        const docs = await getDocuments(courseId, accessToken);
+        const readyDocs = docs.filter((d) => d.status === 'ready');
+
+        const previews = await Promise.allSettled(
+          readyDocs.map(async (doc) => {
+            const preview = await getDocumentPreviewView(doc.id, accessToken);
+            return {
+              documentId: doc.id,
+              filename: doc.filename,
+              sections: (preview.sections ?? []) as Section[],
+              chunks: (preview.sampleChunks ?? []) as Chunk[],
+            };
+          })
+        );
+
+        const loaded = previews
+          .filter(
+            (r): r is PromiseFulfilledResult<DocumentContent> => r.status === 'fulfilled'
+          )
+          .map((r) => r.value)
+          .filter((d) => d.chunks.length > 0 || d.sections.length > 0);
+
+        setContents(loaded);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load course material');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchContent();
+  }, [courseId, accessToken]);
+
+  if (loading) {
+    return (
+      <div className={className} aria-label="Loading course material">
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="animate-pulse">
+              <div className="h-3 w-1/3 bg-gray-200 rounded mb-2" />
+              <div className="h-3 w-full bg-gray-100 rounded mb-1" />
+              <div className="h-3 w-4/5 bg-gray-100 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={className}>
+        <p className="text-xs text-red-500">{error}</p>
+      </div>
+    );
+  }
+
+  if (contents.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={className}>
+      <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+        Course Material
+      </h4>
+      <div className="space-y-6">
+        {contents.map((doc) => (
+          <div key={doc.documentId}>
+            <p
+              className="text-xs font-medium text-gray-600 mb-2 truncate"
+              title={doc.filename}
+            >
+              {doc.filename}
+            </p>
+
+            {/* Section chips — each named section from the parsed document */}
+            {doc.sections.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mb-3">
+                {doc.sections.map((section, i) => (
+                  <span
+                    key={i}
+                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-50 text-orange-700 border border-orange-200"
+                  >
+                    {section.title ?? `Section ${i + 1}`}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Sample chunks — numbered excerpts from the document */}
+            <div className="space-y-2">
+              {doc.chunks.map((chunk, i) => (
+                <div
+                  key={i}
+                  className="rounded-md bg-white border border-gray-200 p-3 text-xs text-gray-700 leading-relaxed"
+                >
+                  <div className="flex items-start gap-2">
+                    <span className="flex-shrink-0 inline-flex items-center justify-center h-4 w-4 rounded-full bg-gray-100 text-gray-500 text-[10px] font-semibold mt-0.5">
+                      {i + 1}
+                    </span>
+                    <p className="flex-1">{chunk.text}</p>
+                  </div>
+                  {chunk.section && (
+                    <p className="mt-1 text-[10px] text-gray-400 pl-6">§ {chunk.section}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/study/LessonNav.tsx
+++ b/apps/web/src/components/study/LessonNav.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { Lesson } from '@/lib/services/courses';
+
+interface LessonNavProps {
+  lessons: Lesson[];
+  selectedLesson: Lesson | null;
+  completedLessons: Set<string>;
+  onSelect: (lesson: Lesson) => void;
+  loading?: boolean;
+}
+
+export function LessonNav({
+  lessons,
+  selectedLesson,
+  completedLessons,
+  onSelect,
+  loading = false,
+}: LessonNavProps) {
+  if (loading) {
+    return (
+      <div className="space-y-1 p-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-10 bg-gray-100 rounded animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (lessons.length === 0) {
+    return (
+      <div className="px-4 py-6 text-center text-sm text-gray-400">
+        No lessons available yet.
+      </div>
+    );
+  }
+
+  return (
+    <nav aria-label="Course lessons">
+      <ul>
+        {lessons.map((lesson, index) => {
+          const lessonId = String(lesson.id);
+          const isSelected = selectedLesson?.id === lesson.id;
+          const isCompleted = completedLessons.has(lessonId);
+
+          return (
+            <li key={lesson.id}>
+              <button
+                onClick={() => onSelect(lesson)}
+                className={`w-full flex items-center gap-3 px-4 py-3 text-left transition-colors border-l-2 ${
+                  isSelected
+                    ? 'border-orange-500 bg-orange-50 text-orange-700'
+                    : 'border-transparent hover:bg-gray-50 text-gray-700'
+                }`}
+                aria-current={isSelected ? 'true' : undefined}
+              >
+                <span
+                  className={`flex-shrink-0 flex items-center justify-center h-6 w-6 rounded-full text-xs font-semibold ${
+                    isCompleted
+                      ? 'bg-green-100 text-green-700'
+                      : isSelected
+                      ? 'bg-orange-100 text-orange-700'
+                      : 'bg-gray-100 text-gray-500'
+                  }`}
+                  aria-hidden="true"
+                >
+                  {isCompleted ? (
+                    <svg
+                      className="h-3.5 w-3.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={2.5}
+                      stroke="currentColor"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                    </svg>
+                  ) : (
+                    index + 1
+                  )}
+                </span>
+                <span className="flex-1 min-w-0 text-sm font-medium truncate">
+                  {lesson.title}
+                </span>
+                {isCompleted && (
+                  <span className="flex-shrink-0 text-xs text-green-600 font-medium">Done</span>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/src/components/study/OutputPane.tsx
+++ b/apps/web/src/components/study/OutputPane.tsx
@@ -154,17 +154,12 @@ export function OutputPane({ courseId, accessToken, selectedLesson }: OutputPane
         ))}
 
         {loading && (
-          <div className="flex justify-start">
-            <div className="bg-gray-100 rounded-xl px-4 py-3" aria-label="Loading response">
-              <div className="flex gap-1">
-                {[0, 1, 2].map((i) => (
-                  <div
-                    key={i}
-                    className="h-2 w-2 rounded-full bg-gray-400 animate-bounce"
-                    style={{ animationDelay: `${i * 150}ms` }}
-                  />
-                ))}
-              </div>
+          <div className="flex justify-start w-full" aria-label="Loading response" aria-live="polite">
+            <div className="bg-gray-100 rounded-xl px-4 py-3 w-full max-w-[85%] space-y-2">
+              <p className="text-xs text-gray-400 mb-1">Thinking…</p>
+              <div className="h-3 rounded bg-gray-300 animate-pulse w-full" />
+              <div className="h-3 rounded bg-gray-300 animate-pulse w-4/5" />
+              <div className="h-3 rounded bg-gray-300 animate-pulse w-3/5" />
             </div>
           </div>
         )}

--- a/apps/web/src/components/study/OutputPane.tsx
+++ b/apps/web/src/components/study/OutputPane.tsx
@@ -1,37 +1,214 @@
 'use client';
 
-export function OutputPane() {
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+import { sendChatMessage, type Citation } from '@/lib/services/chat';
+import type { Lesson } from '@/lib/services/courses';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+  citations?: Citation[];
+}
+
+interface OutputPaneProps {
+  courseId: string;
+  accessToken?: string;
+  selectedLesson?: Lesson | null;
+}
+
+export function OutputPane({ courseId, accessToken, selectedLesson }: OutputPaneProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, loading]);
+
+  async function handleSend() {
+    const question = input.trim();
+    if (!question || loading) return;
+
+    setInput('');
+    setMessages((prev) => [...prev, { role: 'user', content: question }]);
+    setLoading(true);
+
+    try {
+      const result = await sendChatMessage(courseId, question, accessToken);
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          content: result.answer,
+          citations: result.citations,
+        },
+      ]);
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          content:
+            err instanceof Error
+              ? `Error: ${err.message}`
+              : 'Could not fetch a response. Please try again.',
+        },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  const placeholder = selectedLesson
+    ? `Ask about "${selectedLesson.title}"…`
+    : 'Ask a question about the course material…';
+
   return (
-    <div className="h-full flex flex-col">
-      <div className="flex-shrink-0 px-6 py-4 border-b border-gray-200 bg-white">
+    <div className="h-full flex flex-col bg-white">
+      {/* Header */}
+      <div className="flex-shrink-0 px-6 py-4 border-b border-gray-200">
         <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
-          Explanation
+          AI Tutor
         </h2>
+        <p className="mt-0.5 text-xs text-gray-500">
+          Ask questions about the course material
+        </p>
       </div>
 
-      <div className="flex-1 flex items-center justify-center p-8 bg-white">
-        <div className="text-center max-w-sm">
-          <svg
-            className="mx-auto h-12 w-12 text-gray-300"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1}
-            stroke="currentColor"
+      {/* Message thread */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.length === 0 && (
+          <div className="flex items-center justify-center h-full">
+            <div className="text-center max-w-xs">
+              <svg
+                className="mx-auto h-12 w-12 text-gray-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
+                />
+              </svg>
+              <p className="mt-3 text-sm text-gray-500">
+                Ask me anything about the course content. I will find relevant passages and explain them.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg, i) => (
+          <div
+            key={i}
+            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
-            />
-          </svg>
-          <h3 className="mt-4 text-sm font-medium text-gray-900">
-            No explanation generated
-          </h3>
-          <p className="mt-1 text-sm text-gray-500">
-            Once a document is selected and processed, the reconstructed explanation
-            will appear here with source-grounded references.
-          </p>
+            <div
+              className={`max-w-[85%] rounded-xl px-4 py-3 ${
+                msg.role === 'user'
+                  ? 'bg-orange-600 text-white'
+                  : 'bg-gray-100 text-gray-900'
+              }`}
+            >
+              <p className="text-sm whitespace-pre-wrap leading-relaxed">{msg.content}</p>
+
+              {msg.role === 'assistant' &&
+                msg.citations &&
+                msg.citations.length > 0 && (
+                  <div className="mt-3 space-y-2 border-t border-gray-200 pt-2">
+                    <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                      Sources
+                    </p>
+                    {msg.citations.map((citation, ci) => (
+                      <div
+                        key={ci}
+                        className="rounded-md bg-white border border-gray-200 px-3 py-2"
+                      >
+                        <p className="text-xs text-gray-700 line-clamp-3 leading-relaxed">
+                          &ldquo;{citation.snippet}&rdquo;
+                        </p>
+                        <p className="mt-1 text-xs text-gray-400">
+                          Relevance: {Math.round(citation.score * 100)}%
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                )}
+            </div>
+          </div>
+        ))}
+
+        {loading && (
+          <div className="flex justify-start">
+            <div className="bg-gray-100 rounded-xl px-4 py-3" aria-label="Loading response">
+              <div className="flex gap-1">
+                {[0, 1, 2].map((i) => (
+                  <div
+                    key={i}
+                    className="h-2 w-2 rounded-full bg-gray-400 animate-bounce"
+                    style={{ animationDelay: `${i * 150}ms` }}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input area */}
+      <div className="flex-shrink-0 border-t border-gray-200 p-4">
+        <div className="flex gap-3">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            rows={2}
+            disabled={loading}
+            aria-label="Message input"
+            className="flex-1 resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500 disabled:opacity-50"
+          />
+          <button
+            onClick={handleSend}
+            disabled={!input.trim() || loading}
+            aria-label="Send message"
+            className="flex-shrink-0 inline-flex items-center justify-center h-10 w-10 self-end rounded-lg bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
+              />
+            </svg>
+          </button>
         </div>
+        <p className="mt-1.5 text-xs text-gray-400">
+          Enter to send · Shift+Enter for a new line
+        </p>
       </div>
     </div>
   );

--- a/apps/web/src/components/study/SourcePane.tsx
+++ b/apps/web/src/components/study/SourcePane.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { LessonNav } from './LessonNav';
+import { ContentChunks } from './ContentChunks';
 import type { Lesson } from '@/lib/services/courses';
 
 interface SourcePaneProps {
+  courseId: string;
+  accessToken?: string;
   courseTitle?: string;
   lessons: Lesson[];
   selectedLesson: Lesson | null;
@@ -14,6 +17,8 @@ interface SourcePaneProps {
 }
 
 export function SourcePane({
+  courseId,
+  accessToken,
   courseTitle,
   lessons,
   selectedLesson,
@@ -57,30 +62,18 @@ export function SourcePane({
               {selectedLesson.title}
             </h3>
 
-            {selectedLesson.content ? (
+            {selectedLesson.content && (
               <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">
                 {selectedLesson.content}
               </p>
-            ) : (
-              <div className="rounded-lg border border-dashed border-gray-300 bg-white p-5 text-center">
-                <svg
-                  className="mx-auto h-8 w-8 text-gray-300"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.5}
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
-                  />
-                </svg>
-                <p className="mt-2 text-sm text-gray-500">
-                  Use the AI Tutor to explore the course material for this lesson.
-                </p>
-              </div>
             )}
+
+            {/* Document chunks from uploaded course material */}
+            <ContentChunks
+              courseId={courseId}
+              accessToken={accessToken}
+              className="mt-2"
+            />
 
             {/* Completion button */}
             <div className="pt-2">

--- a/apps/web/src/components/study/SourcePane.tsx
+++ b/apps/web/src/components/study/SourcePane.tsx
@@ -1,44 +1,137 @@
 'use client';
 
+import { LessonNav } from './LessonNav';
+import type { Lesson } from '@/lib/services/courses';
+
 interface SourcePaneProps {
   courseTitle?: string;
+  lessons: Lesson[];
+  selectedLesson: Lesson | null;
+  completedLessons: Set<string>;
+  onSelectLesson: (lesson: Lesson) => void;
+  onMarkComplete: (lesson: Lesson) => Promise<void>;
+  loadingLessons?: boolean;
 }
 
-export function SourcePane({ courseTitle }: SourcePaneProps) {
+export function SourcePane({
+  courseTitle,
+  lessons,
+  selectedLesson,
+  completedLessons,
+  onSelectLesson,
+  onMarkComplete,
+  loadingLessons = false,
+}: SourcePaneProps) {
+  const isCompleted = selectedLesson
+    ? completedLessons.has(String(selectedLesson.id))
+    : false;
+
   return (
     <div className="h-full flex flex-col">
+      {/* Header */}
       <div className="flex-shrink-0 px-6 py-4 border-b border-gray-200 bg-white">
         <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
-          Source Material
+          Study Path
         </h2>
         {courseTitle && (
           <p className="mt-0.5 text-xs text-gray-500">{courseTitle}</p>
         )}
       </div>
 
-      <div className="flex-1 flex items-center justify-center p-8 bg-gray-50">
-        <div className="text-center max-w-sm">
-          <svg
-            className="mx-auto h-12 w-12 text-gray-300"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
-            />
-          </svg>
-          <h3 className="mt-4 text-sm font-medium text-gray-900">
-            No document selected
-          </h3>
-          <p className="mt-1 text-sm text-gray-500">
-            Select a document from the course workspace to view its contents here.
-            Citations and highlights will be synced with the explanation panel.
-          </p>
-        </div>
+      {/* Lesson list — capped height so content is still visible */}
+      <div className="flex-shrink-0 border-b border-gray-200 overflow-y-auto max-h-56 bg-white">
+        <LessonNav
+          lessons={lessons}
+          selectedLesson={selectedLesson}
+          completedLessons={completedLessons}
+          onSelect={onSelectLesson}
+          loading={loadingLessons}
+        />
+      </div>
+
+      {/* Lesson content */}
+      <div className="flex-1 overflow-y-auto bg-gray-50">
+        {selectedLesson ? (
+          <div className="p-6 space-y-4">
+            <h3 className="text-base font-semibold text-gray-900">
+              {selectedLesson.title}
+            </h3>
+
+            {selectedLesson.content ? (
+              <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">
+                {selectedLesson.content}
+              </p>
+            ) : (
+              <div className="rounded-lg border border-dashed border-gray-300 bg-white p-5 text-center">
+                <svg
+                  className="mx-auto h-8 w-8 text-gray-300"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
+                  />
+                </svg>
+                <p className="mt-2 text-sm text-gray-500">
+                  Use the AI Tutor to explore the course material for this lesson.
+                </p>
+              </div>
+            )}
+
+            {/* Completion button */}
+            <div className="pt-2">
+              {isCompleted ? (
+                <div className="flex items-center gap-2 text-sm text-green-600 font-medium">
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2.5}
+                    stroke="currentColor"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                  </svg>
+                  Lesson completed
+                </div>
+              ) : (
+                <button
+                  onClick={() => onMarkComplete(selectedLesson)}
+                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-orange-600 rounded-md hover:bg-orange-700 transition-colors focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
+                >
+                  Mark as complete
+                </button>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-full p-8">
+            <div className="text-center max-w-sm">
+              <svg
+                className="mx-auto h-12 w-12 text-gray-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4.26 10.147a60.438 60.438 0 00-.491 6.347A48.62 48.62 0 0112 20.904a48.62 48.62 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.636 50.636 0 00-2.658-.813A59.906 59.906 0 0112 3.493a59.903 59.903 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0112 13.489a50.702 50.702 0 017.74-3.342"
+                />
+              </svg>
+              <h3 className="mt-4 text-sm font-medium text-gray-900">
+                Select a lesson to begin
+              </h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Choose a lesson from the list above to view its content and start studying.
+              </p>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/ui/BadgeDisplay.tsx
+++ b/apps/web/src/components/ui/BadgeDisplay.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { Badge } from '@/lib/services/progress';
+
+interface BadgeDisplayProps {
+  badge: Badge;
+  size?: 'sm' | 'md';
+}
+
+export function BadgeDisplay({ badge, size = 'md' }: BadgeDisplayProps) {
+  const iconSize = size === 'sm' ? 'text-lg' : 'text-3xl';
+  const padding = size === 'sm' ? 'px-2 py-1' : 'px-3 py-2';
+
+  return (
+    <div
+      className={`inline-flex items-center gap-2 rounded-lg bg-yellow-50 border border-yellow-200 ${padding}`}
+      title={badge.description}
+      role="img"
+      aria-label={`Badge: ${badge.name}`}
+    >
+      <span className={iconSize} aria-hidden="true">
+        {badge.icon}
+      </span>
+      <div>
+        <p className="text-xs font-semibold text-yellow-800">{badge.name}</p>
+        {size === 'md' && (
+          <p className="text-xs text-yellow-600">{badge.description}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/ErrorBoundary.tsx
+++ b/apps/web/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ErrorBoundary] Caught rendering error:', error, info.componentStack);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+
+      return (
+        <div className="flex flex-col items-center justify-center h-full p-6 text-center">
+          <svg
+            className="h-10 w-10 text-gray-300 mb-3"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+            />
+          </svg>
+          <p className="text-sm text-gray-600 mb-3">Something went wrong in this section.</p>
+          <button
+            onClick={this.handleReset}
+            className="text-sm font-medium text-orange-600 hover:text-orange-700 underline"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/web/src/components/ui/ProgressBar.tsx
+++ b/apps/web/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+interface ProgressBarProps {
+  percent: number;
+  label?: string;
+  showPercent?: boolean;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+export function ProgressBar({
+  percent,
+  label,
+  showPercent = true,
+  size = 'sm',
+  className = '',
+}: ProgressBarProps) {
+  const clamped = Math.max(0, Math.min(100, percent));
+  const barHeight = size === 'sm' ? 'h-1.5' : 'h-2.5';
+  const barColor = clamped === 100 ? 'bg-green-500' : 'bg-orange-500';
+
+  return (
+    <div className={className}>
+      {(label || showPercent) && (
+        <div className="flex justify-between items-center mb-1">
+          {label && <span className="text-xs text-gray-500">{label}</span>}
+          {showPercent && (
+            <span className="text-xs font-medium text-gray-700">{clamped}%</span>
+          )}
+        </div>
+      )}
+      <div
+        className={`w-full bg-gray-200 rounded-full ${barHeight}`}
+        role="progressbar"
+        aria-valuenow={clamped}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={label ?? `Progress: ${clamped}%`}
+      >
+        <div
+          className={`${barColor} ${barHeight} rounded-full transition-all duration-500`}
+          style={{ width: `${clamped}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -63,13 +63,19 @@ export interface ApiDocumentDetail {
   updated_at: string;
 }
 
+export interface ApiPreviewChunk {
+  text: string;
+  label: string | null;
+  section: string | null;
+}
+
 export interface ApiDocumentPreview {
   id: string;
   filename: string;
   extracted_text_preview: string | null;
   page_count: number | null;
-  sections: Array<Record<string, unknown>> | null;
-  sample_chunks: Array<Record<string, unknown>> | null;
+  sections: string[] | null;
+  sample_chunks: ApiPreviewChunk[] | null;
 }
 
 export interface CreateCourseRequest {
@@ -116,6 +122,6 @@ export interface DocumentPreviewView {
   filename: string;
   extractedTextPreview: string | null;
   pageCount: number | null;
-  sections: Array<Record<string, unknown>> | null;
-  sampleChunks: Array<Record<string, unknown>> | null;
+  sections: string[] | null;
+  sampleChunks: ApiPreviewChunk[] | null;
 }

--- a/apps/web/src/lib/services/chat.ts
+++ b/apps/web/src/lib/services/chat.ts
@@ -1,0 +1,29 @@
+import { apiFetch } from '@/lib/api';
+
+export interface Citation {
+  snippet: string;
+  score: number;
+}
+
+export interface ChatResponse {
+  answer: string;
+  citations: Citation[];
+  retrievalUsed: boolean;
+}
+
+export async function sendChatMessage(
+  courseId: string,
+  message: string,
+  accessToken?: string
+): Promise<ChatResponse> {
+  const raw = await apiFetch<Record<string, unknown>>(`/courses/${courseId}/chat`, {
+    method: 'POST',
+    body: { message },
+    accessToken,
+  });
+  return {
+    answer: raw.answer as string,
+    citations: (raw.citations as Citation[]) ?? [],
+    retrievalUsed: raw.retrieval_used as boolean,
+  };
+}

--- a/apps/web/src/lib/services/progress.ts
+++ b/apps/web/src/lib/services/progress.ts
@@ -1,0 +1,100 @@
+import { apiFetch } from '@/lib/api';
+
+export interface CourseProgress {
+  courseId: string;
+  percent: number;
+  status: string;
+  lessonCount: number;
+  completedCount: number;
+  updatedAt: string;
+}
+
+export interface Badge {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  icon: string;
+}
+
+export interface UserBadge {
+  id: string;
+  badge: Badge;
+  earnedAt: string;
+  contextId: string | null;
+}
+
+export interface ProgressUpdateResult {
+  lessonProgress: {
+    lessonId: string;
+    status: 'not_started' | 'in_progress' | 'completed';
+    lastScore: number | null;
+  };
+  courseProgress: CourseProgress;
+  newBadges: Badge[];
+}
+
+function mapProgress(raw: Record<string, unknown>): CourseProgress {
+  return {
+    courseId: raw.course_id as string,
+    percent: raw.percent as number,
+    status: raw.status as string,
+    lessonCount: raw.lesson_count as number,
+    completedCount: raw.completed_count as number,
+    updatedAt: raw.updated_at as string,
+  };
+}
+
+function mapBadge(raw: Record<string, unknown>): Badge {
+  return {
+    id: raw.id as string,
+    slug: raw.slug as string,
+    name: raw.name as string,
+    description: raw.description as string,
+    icon: raw.icon as string,
+  };
+}
+
+export async function getCourseProgress(
+  courseId: string,
+  accessToken?: string
+): Promise<CourseProgress> {
+  const raw = await apiFetch<Record<string, unknown>>(`/progress/${courseId}`, { accessToken });
+  return mapProgress(raw);
+}
+
+export async function markLessonComplete(
+  lessonId: string,
+  courseId: string,
+  accessToken?: string
+): Promise<ProgressUpdateResult> {
+  const raw = await apiFetch<Record<string, unknown>>('/progress/update', {
+    method: 'POST',
+    body: { lesson_id: lessonId, course_id: courseId, status: 'completed' },
+    accessToken,
+  });
+
+  const lp = raw.lesson_progress as Record<string, unknown>;
+  const cp = raw.course_progress as Record<string, unknown>;
+  const nb = (raw.new_badges as Record<string, unknown>[]) ?? [];
+
+  return {
+    lessonProgress: {
+      lessonId: lp.lesson_id as string,
+      status: lp.status as 'not_started' | 'in_progress' | 'completed',
+      lastScore: lp.last_score as number | null,
+    },
+    courseProgress: mapProgress(cp),
+    newBadges: nb.map(mapBadge),
+  };
+}
+
+export async function getUserBadges(accessToken?: string): Promise<UserBadge[]> {
+  const raw = await apiFetch<Record<string, unknown>[]>('/badges/user', { accessToken });
+  return raw.map((item) => ({
+    id: item.id as string,
+    badge: mapBadge(item.badge as Record<string, unknown>),
+    earnedAt: item.earned_at as string,
+    contextId: item.context_id as string | null,
+  }));
+}

--- a/apps/web/src/lib/services/progress.ts
+++ b/apps/web/src/lib/services/progress.ts
@@ -7,6 +7,7 @@ export interface CourseProgress {
   lessonCount: number;
   completedCount: number;
   updatedAt: string;
+  completedLessonIds: string[];
 }
 
 export interface Badge {
@@ -42,6 +43,7 @@ function mapProgress(raw: Record<string, unknown>): CourseProgress {
     lessonCount: raw.lesson_count as number,
     completedCount: raw.completed_count as number,
     updatedAt: raw.updated_at as string,
+    completedLessonIds: (raw.completed_lesson_ids as string[]) ?? [],
   };
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,17 +16,15 @@ services:
       retries: 5
 
   qvac:
-    image: node:22-alpine
-    working_dir: /app
-    command: node src/server.js
+    build: ./workers/qvac-service
     ports:
       - "3001:3001"
     volumes:
-      - ./workers/qvac-service:/app
-      - /app/node_modules
       - qvac_data:/app/hyperdb
+      - qvac_ingest:/qvac_ingest
     environment:
       - QVAC_PORT=3001
+      - QVAC_INGEST_DIR=/qvac_ingest
       # Set QVAC_LLM_SRC to a local model path to enable LLM generation.
       # Leave unset to run in embedding + retrieval only mode.
     healthcheck:
@@ -42,6 +40,7 @@ services:
       - "8000:8000"
     volumes:
       - ./services/ai:/app
+      - qvac_ingest:/qvac_ingest
     env_file:
       - ./services/ai/.env
     environment:
@@ -49,6 +48,7 @@ services:
       - ENVIRONMENT=development
       - CORS_ORIGINS=http://localhost:3000
       - QVAC_SERVICE_URL=http://qvac:3001
+      - QVAC_INGEST_DIR=/qvac_ingest
     depends_on:
       postgres:
         condition: service_healthy
@@ -75,3 +75,4 @@ services:
 volumes:
   postgres_data:
   qvac_data:
+  qvac_ingest:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,26 @@ services:
       timeout: 5s
       retries: 5
 
+  qvac:
+    image: node:22-alpine
+    working_dir: /app
+    command: node src/server.js
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./workers/qvac-service:/app
+      - /app/node_modules
+      - qvac_data:/app/hyperdb
+    environment:
+      - QVAC_PORT=3001
+      # Set QVAC_LLM_SRC to a local model path to enable LLM generation.
+      # Leave unset to run in embedding + retrieval only mode.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3001/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   api:
     build:
       context: ./services/ai
@@ -28,8 +48,11 @@ services:
       - DATABASE_URL=postgresql://bitcoin_academy:bitcoin_academy@postgres:5432/bitcoin_academy
       - ENVIRONMENT=development
       - CORS_ORIGINS=http://localhost:3000
+      - QVAC_SERVICE_URL=http://qvac:3001
     depends_on:
       postgres:
+        condition: service_healthy
+      qvac:
         condition: service_healthy
 
   web:
@@ -51,3 +74,4 @@ services:
 
 volumes:
   postgres_data:
+  qvac_data:

--- a/package.json
+++ b/package.json
@@ -4,17 +4,20 @@
   "private": true,
   "workspaces": [
     "apps/*",
-    "services/*"
+    "services/*",
+    "workers/qvac-service"
   ],
   "scripts": {
     "dev:web": "cd apps/web && npm run dev",
     "dev:api": "cd services/ai && npm run dev",
+    "dev:qvac": "cd workers/qvac-service && node src/server.js",
     "build:web": "cd apps/web && npm run build",
     "build:api": "cd services/ai && npm run build",
     "type-check": "cd apps/web && npm run type-check && cd ../../services/ai && npm run type-check",
-    "test": "npm run test:web && npm run test:api",
+    "test": "npm run test:web && npm run test:api && npm run test:qvac",
     "test:web": "cd apps/web && npm run test",
     "test:api": "cd services/ai && pytest",
+    "test:qvac": "cd workers/qvac-service && npm test",
     "test:watch": "cd apps/web && npm run test:watch",
     "lint": "eslint apps/web/src services/ai/app --ext .ts,.tsx,.py --max-warnings 0",
     "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",

--- a/services/ai/.env.example
+++ b/services/ai/.env.example
@@ -24,5 +24,20 @@ CORS_ORIGINS=http://localhost:3000
 # --- ALLOWED_HOSTS (production only) -----------------------------------
 # ALLOWED_HOSTS=academy.example.com
 
-# --- AI / RAG (required for chat and document indexing) ----------------
-OPENAI_API_KEY=sk-...
+# --- AI / LLM (optional — system works without it; generation actions return fallback text) ---
+OPENAI_API_KEY=
+
+# --- ChromaDB (local vector store path) ----------------------------------------
+CHROMA_DB_PATH=./chroma_data
+
+# --- Retrieval tuning ----------------------------------------------------------
+RAG_TOP_K=10
+
+# --- LLM generation timeout (seconds) -----------------------------------------
+LLM_TIMEOUT_SECONDS=30
+
+# --- Debug mode (enables /api/debug/* endpoints — never enable in production) ---
+DEBUG_MODE=false
+
+# --- QVAC integration (optional — bypassed when QVAC_SERVICE_URL is unset) ------
+QVAC_SERVICE_URL=

--- a/services/ai/app/api/chat_api.py
+++ b/services/ai/app/api/chat_api.py
@@ -1,5 +1,5 @@
 """Chat API controller - RAG-backed Q&A endpoint."""
-from typing import List, Optional
+from typing import List
 
 from fastapi import APIRouter, Depends, Path
 from pydantic import BaseModel, Field
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/api", tags=["Chat"])
 
 
 # ---------------------------------------------------------------------------
-# Request / Response schemas (inline — chat is self-contained)
+# Request / Response schemas
 # ---------------------------------------------------------------------------
 
 class ChatRequest(BaseModel):
@@ -19,11 +19,8 @@ class ChatRequest(BaseModel):
 
 
 class CitationOut(BaseModel):
-    label: str
-    section: Optional[str] = None
-    page: Optional[int] = None
-    slide: Optional[int] = None
-    text_snippet: str
+    snippet: str
+    score: float
 
 
 class ChatResponse(BaseModel):
@@ -41,9 +38,9 @@ class ChatResponse(BaseModel):
     response_model=ChatResponse,
     summary="Ask a question about course materials",
     description=(
-        "Retrieves relevant passages from the indexed course documents and "
-        "synthesises an answer. Requires a valid JWT. "
-        "Falls back to raw context when no OpenAI key is configured."
+        "Retrieves relevant passages from the indexed course documents via the "
+        "QVAC service and synthesises an answer. Requires a valid JWT. "
+        "Falls back to a plain message when the QVAC service is unavailable."
     ),
 )
 def chat(
@@ -54,15 +51,6 @@ def chat(
     result = chat_service.answer(question=body.message, course_id=course_id)
     return ChatResponse(
         answer=result.answer,
-        citations=[
-            CitationOut(
-                label=c.label,
-                section=c.section,
-                page=c.page,
-                slide=c.slide,
-                text_snippet=c.text_snippet,
-            )
-            for c in result.citations
-        ],
+        citations=[CitationOut(snippet=c.snippet, score=c.score) for c in result.citations],
         retrieval_used=result.retrieval_used,
     )

--- a/services/ai/app/api/chat_api.py
+++ b/services/ai/app/api/chat_api.py
@@ -21,6 +21,11 @@ class ChatRequest(BaseModel):
 class CitationOut(BaseModel):
     snippet: str
     score: float
+    label: str = ""
+    page: int = 0
+    slide: int = 0
+    section: str = ""
+    doc_id: str = ""
 
 
 class ChatResponse(BaseModel):
@@ -43,14 +48,25 @@ class ChatResponse(BaseModel):
         "Falls back to a plain message when the QVAC service is unavailable."
     ),
 )
-def chat(
+async def chat(
     body: ChatRequest,
     course_id: str = Path(..., description="Course whose documents to search"),
     _current_user: CurrentUser = Depends(get_current_user),
 ) -> ChatResponse:
-    result = chat_service.answer(question=body.message, course_id=course_id)
+    result = await chat_service.answer(question=body.message, course_id=course_id)
     return ChatResponse(
         answer=result.answer,
-        citations=[CitationOut(snippet=c.snippet, score=c.score) for c in result.citations],
+        citations=[
+            CitationOut(
+                snippet=c.snippet,
+                score=c.score,
+                label=c.label,
+                page=c.page,
+                slide=c.slide,
+                section=c.section,
+                doc_id=c.doc_id,
+            )
+            for c in result.citations
+        ],
         retrieval_used=result.retrieval_used,
     )

--- a/services/ai/app/api/study_api.py
+++ b/services/ai/app/api/study_api.py
@@ -1,0 +1,79 @@
+"""Study API — action-aware RAG endpoints."""
+from typing import List
+
+from fastapi import APIRouter, Depends, Path
+
+from app.middleware.auth import CurrentUser, get_current_user
+from app.schemas.study_schemas import (
+    STUDY_ACTION_REGISTRY,
+    ActionMetaOut,
+    CitationOut,
+    StudyActionsResponse,
+    StudyDispatchRequest,
+    StudyDispatchResponse,
+)
+from app.services import study_service
+
+router = APIRouter(prefix="/api", tags=["Study"])
+
+
+@router.post(
+    "/courses/{course_id}/study",
+    response_model=StudyDispatchResponse,
+    summary="Run a study action on course material",
+    description=(
+        "Retrieves relevant passages and applies the requested study action "
+        "(explain, summarize, retrieve, open_questions, quiz, oral). "
+        "Falls back gracefully when the QVAC service or LLM is unavailable."
+    ),
+)
+async def study(
+    body: StudyDispatchRequest,
+    course_id: str = Path(..., description="Course whose documents to search"),
+    _current_user: CurrentUser = Depends(get_current_user),
+) -> StudyDispatchResponse:
+    result = await study_service.dispatch(
+        question=body.query,
+        course_id=course_id,
+        action=body.action,
+    )
+    return StudyDispatchResponse(
+        answer=result.answer,
+        citations=[
+            CitationOut(
+                snippet=c.snippet,
+                score=c.score,
+                label=c.label,
+                page=c.page,
+                slide=c.slide,
+                section=c.section,
+                doc_id=c.doc_id,
+            )
+            for c in result.citations
+        ],
+        retrieval_used=result.retrieval_used,
+        action=body.action.value,
+    )
+
+
+@router.get(
+    "/study/actions",
+    response_model=StudyActionsResponse,
+    summary="List available study actions",
+    description="Returns the full STUDY_ACTION_REGISTRY — useful for dynamic frontend rendering.",
+)
+def list_study_actions() -> StudyActionsResponse:
+    actions: List[ActionMetaOut] = [
+        ActionMetaOut(
+            action=action.value,
+            name=meta.name,
+            description=meta.description,
+            retrieval_required=meta.retrieval_required,
+            generation_required=meta.generation_required,
+            output_type=meta.output_type,
+            source_grounding_required=meta.source_grounding_required,
+            example_query=meta.example_query,
+        )
+        for action, meta in STUDY_ACTION_REGISTRY.items()
+    ]
+    return StudyActionsResponse(actions=actions)

--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -15,6 +15,7 @@ from app.api.courses_api import router as courses_router
 from app.api.documents_api import router as documents_router
 from app.api.progress_api import router as progress_router
 from app.api.quizzes_api import router as quizzes_router
+from app.api.study_api import router as study_router
 from app.db.session import init_db, get_db
 from app.core.config import settings
 from app.core.errors import register_exception_handlers
@@ -118,6 +119,7 @@ app.include_router(courses_router)
 app.include_router(documents_router)
 app.include_router(progress_router)
 app.include_router(quizzes_router)
+app.include_router(study_router)
 
 
 @app.get("/", tags=["Root"])

--- a/services/ai/app/repositories/progress_repo.py
+++ b/services/ai/app/repositories/progress_repo.py
@@ -121,3 +121,18 @@ def count_completed_lessons(db: Session, user_id: str, course_id: str) -> int:
         .scalar()
         or 0
     )
+
+
+def get_completed_lesson_ids(db: Session, user_id: str, course_id: str) -> list[str]:
+    rows = (
+        db.query(UserLessonProgress.lesson_id)
+        .join(Lesson, UserLessonProgress.lesson_id == Lesson.id)
+        .join(Chapter, Lesson.chapter_id == Chapter.id)
+        .filter(
+            Chapter.course_id == course_id,
+            UserLessonProgress.user_id == user_id,
+            UserLessonProgress.status == "completed",
+        )
+        .all()
+    )
+    return [row[0] for row in rows]

--- a/services/ai/app/schemas/progress_schemas.py
+++ b/services/ai/app/schemas/progress_schemas.py
@@ -35,6 +35,7 @@ class CourseProgressResponse(BaseModel):
     lesson_count: int
     completed_count: int
     updated_at: str
+    completed_lesson_ids: List[str] = []
 
     class Config:
         from_attributes = True

--- a/services/ai/app/schemas/study_schemas.py
+++ b/services/ai/app/schemas/study_schemas.py
@@ -1,0 +1,133 @@
+"""Study action schemas — enum, registry, and API DTOs."""
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Study action enum
+# ---------------------------------------------------------------------------
+
+class StudyAction(str, Enum):
+    EXPLAIN = "explain"
+    SUMMARIZE = "summarize"
+    RETRIEVE = "retrieve"
+    OPEN_QUESTIONS = "open_questions"
+    QUIZ = "quiz"
+    ORAL = "oral"
+
+
+# ---------------------------------------------------------------------------
+# Action registry
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ActionMeta:
+    name: str
+    description: str
+    retrieval_required: bool
+    generation_required: bool
+    output_type: str  # "prose" | "list" | "chunks" | "qa_pairs"
+    source_grounding_required: bool
+    example_query: str
+
+
+STUDY_ACTION_REGISTRY: Dict[StudyAction, ActionMeta] = {
+    StudyAction.EXPLAIN: ActionMeta(
+        name="Explain",
+        description="Clear prose explanation of the concept using retrieved context",
+        retrieval_required=True,
+        generation_required=True,
+        output_type="prose",
+        source_grounding_required=True,
+        example_query="Explain how Bitcoin mining works",
+    ),
+    StudyAction.SUMMARIZE: ActionMeta(
+        name="Summarize",
+        description="Concise bullet-point summary of the main concepts",
+        retrieval_required=True,
+        generation_required=True,
+        output_type="list",
+        source_grounding_required=False,
+        example_query="Summarize the key properties of Bitcoin",
+    ),
+    StudyAction.RETRIEVE: ActionMeta(
+        name="Retrieve",
+        description="Raw passage retrieval — returns the most relevant source chunks without generation",
+        retrieval_required=True,
+        generation_required=False,
+        output_type="chunks",
+        source_grounding_required=True,
+        example_query="What is a UTXO?",
+    ),
+    StudyAction.OPEN_QUESTIONS: ActionMeta(
+        name="Open Questions",
+        description="Open-ended questions that prompt deeper understanding of the topic",
+        retrieval_required=True,
+        generation_required=True,
+        output_type="list",
+        source_grounding_required=False,
+        example_query="Generate open questions about Bitcoin consensus",
+    ),
+    StudyAction.QUIZ: ActionMeta(
+        name="Quiz",
+        description="Multiple-choice Q&A pairs for self-assessment",
+        retrieval_required=True,
+        generation_required=True,
+        output_type="qa_pairs",
+        source_grounding_required=True,
+        example_query="Quiz me on Bitcoin transaction structure",
+    ),
+    StudyAction.ORAL: ActionMeta(
+        name="Oral",
+        description="Simulated oral exam questions with model answers",
+        retrieval_required=True,
+        generation_required=True,
+        output_type="qa_pairs",
+        source_grounding_required=True,
+        example_query="Prepare oral exam questions about Merkle trees",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# API DTOs
+# ---------------------------------------------------------------------------
+
+class StudyDispatchRequest(BaseModel):
+    query: str = Field(..., min_length=1, max_length=2000)
+    action: StudyAction
+
+
+class CitationOut(BaseModel):
+    snippet: str
+    score: float
+    label: str = ""
+    page: int = 0
+    slide: int = 0
+    section: str = ""
+    doc_id: str = ""
+
+
+class StudyDispatchResponse(BaseModel):
+    answer: str
+    citations: List[CitationOut]
+    retrieval_used: bool
+    action: str
+
+
+class ActionMetaOut(BaseModel):
+    action: str
+    name: str
+    description: str
+    retrieval_required: bool
+    generation_required: bool
+    output_type: str
+    source_grounding_required: bool
+    example_query: str
+
+
+class StudyActionsResponse(BaseModel):
+    actions: List[ActionMetaOut]

--- a/services/ai/app/services/chat_service.py
+++ b/services/ai/app/services/chat_service.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 _QVAC_SERVICE_URL = os.getenv("QVAC_SERVICE_URL", "http://localhost:3001")
 _TOP_K = int(os.getenv("RAG_TOP_K", "5"))
 
+_client = httpx.AsyncClient(base_url=_QVAC_SERVICE_URL, timeout=60.0)
+
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -27,6 +29,11 @@ _TOP_K = int(os.getenv("RAG_TOP_K", "5"))
 class Citation:
     snippet: str
     score: float
+    label: str = ""
+    page: int = 0
+    slide: int = 0
+    section: str = ""
+    doc_id: str = ""
 
 
 @dataclass
@@ -40,7 +47,7 @@ class ChatResult:
 # Public API
 # ---------------------------------------------------------------------------
 
-def answer(question: str, course_id: str) -> ChatResult:
+async def answer(question: str, course_id: str) -> ChatResult:
     """Send the question to the QVAC /query endpoint and return a ChatResult.
 
     retrieval_used is True only when the QVAC service returned at least one
@@ -48,13 +55,11 @@ def answer(question: str, course_id: str) -> ChatResult:
     retrieval was skipped.
     """
     try:
-        resp = httpx.post(
-            f"{_QVAC_SERVICE_URL}/query",
+        resp = await _client.post(
+            "/query",
             json={"question": question, "workspace": course_id, "topK": _TOP_K},
-            timeout=60.0,
         )
         resp.raise_for_status()
-        data = resp.json()
     except httpx.HTTPError as exc:
         logger.warning("QVAC service unavailable: %s", exc)
         return ChatResult(
@@ -62,9 +67,32 @@ def answer(question: str, course_id: str) -> ChatResult:
             retrieval_used=False,
         )
 
-    sources = data.get("sources", [])
+    try:
+        data = resp.json()
+        answer_text = data["answer"]
+        sources = data.get("sources", [])
+    except (ValueError, KeyError) as exc:
+        logger.error("Unexpected QVAC response: %s — %.200s", exc, resp.text)
+        return ChatResult(
+            answer="Received an unexpected response from the AI service.",
+            retrieval_used=False,
+        )
+
+    citations = [
+        Citation(
+            snippet=s.get("snippet", ""),
+            score=s.get("score", 0.0),
+            label=s.get("label", ""),
+            page=s.get("page", 0),
+            slide=s.get("slide", 0),
+            section=s.get("section", ""),
+            doc_id=s.get("doc_id", ""),
+        )
+        for s in sources
+    ]
+
     return ChatResult(
-        answer=data["answer"],
-        citations=[Citation(snippet=s["snippet"], score=s["score"]) for s in sources],
+        answer=answer_text,
+        citations=citations,
         retrieval_used=bool(sources),
     )

--- a/services/ai/app/services/chat_service.py
+++ b/services/ai/app/services/chat_service.py
@@ -1,28 +1,32 @@
-"""Chat service — RAG orchestration: retrieval + optional LLM synthesis."""
+"""Chat service — forwards RAG queries to the QVAC Node.js service.
+
+The QVAC service owns embedding, HyperDB retrieval, and optional LLM synthesis.
+This module is only responsible for the HTTP call and mapping the response to
+the ChatResult type consumed by chat_api.py.
+
+QVAC workspace = course_id, matching the convention in pipeline.py and ingest.js.
+"""
 import logging
 import os
 from dataclasses import dataclass, field
-from functools import lru_cache
-from typing import List, Optional
+from typing import List
+
+import httpx
 
 logger = logging.getLogger(__name__)
 
-_CHROMA_DB_PATH = os.getenv("CHROMA_DB_PATH", "")
-_OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+_QVAC_SERVICE_URL = os.getenv("QVAC_SERVICE_URL", "http://localhost:3001")
 _TOP_K = int(os.getenv("RAG_TOP_K", "5"))
 
 
 # ---------------------------------------------------------------------------
-# Data classes (no Pydantic — service layer only)
+# Data types
 # ---------------------------------------------------------------------------
 
 @dataclass
 class Citation:
-    label: str
-    section: Optional[str]
-    page: Optional[int]
-    slide: Optional[int]
-    text_snippet: str
+    snippet: str
+    score: float
 
 
 @dataclass
@@ -33,161 +37,34 @@ class ChatResult:
 
 
 # ---------------------------------------------------------------------------
-# ChromaDB singleton
-# ---------------------------------------------------------------------------
-
-@lru_cache(maxsize=1)
-def _get_chroma_collection():
-    """Return the shared ChromaDB collection, initialised once per process."""
-    import chromadb
-    from chromadb.config import Settings as ChromaSettings
-    from pathlib import Path
-
-    if not _CHROMA_DB_PATH:
-        # Derive default relative to this file: services/ai/chroma_db
-        chroma_path = str(Path(__file__).resolve().parents[2] / "chroma_db")
-    else:
-        chroma_path = _CHROMA_DB_PATH
-
-    client = chromadb.PersistentClient(
-        path=chroma_path,
-        settings=ChromaSettings(anonymized_telemetry=False),
-    )
-    return client.get_or_create_collection(
-        name="bitpolito_course",
-        metadata={"hnsw:space": "cosine"},
-    )
-
-
-# ---------------------------------------------------------------------------
-# Retrieval
-# ---------------------------------------------------------------------------
-
-def _retrieve(query: str, course_id: str, top_k: int = _TOP_K) -> List[dict]:
-    """Embed query and search ChromaDB, filtered to the given course."""
-    from fastembed import TextEmbedding
-
-    model = TextEmbedding("sentence-transformers/all-MiniLM-L6-v2")
-    query_vec = list(model.embed([query]))[0].tolist()
-
-    collection = _get_chroma_collection()
-
-    # Filter to only chunks belonging to this course
-    where: dict = {"course_id": course_id}
-
-    try:
-        results = collection.query(
-            query_embeddings=[query_vec],
-            n_results=top_k,
-            where=where,
-        )
-    except Exception as exc:
-        logger.warning("ChromaDB query failed (possibly empty collection): %s", exc)
-        return []
-
-    hits = []
-    if results["ids"] and results["ids"][0]:
-        for i, chunk_id in enumerate(results["ids"][0]):
-            meta = results["metadatas"][0][i] if results["metadatas"] else {}
-            hits.append({
-                "id": chunk_id,
-                "text": results["documents"][0][i] if results["documents"] else "",
-                "distance": results["distances"][0][i] if results["distances"] else 1.0,
-                "label": meta.get("label", ""),
-                "section": meta.get("section", ""),
-                "page": meta.get("page"),
-                "slide": meta.get("slide"),
-            })
-    return hits
-
-
-def _build_context(hits: List[dict]) -> str:
-    parts = []
-    for i, h in enumerate(hits, 1):
-        loc = h.get("label") or h.get("section") or f"chunk {i}"
-        parts.append(f"[{i}] ({loc})\n{h['text']}")
-    return "\n\n---\n\n".join(parts)
-
-
-# ---------------------------------------------------------------------------
-# LLM synthesis (optional — gracefully skipped if no API key)
-# ---------------------------------------------------------------------------
-
-_SYSTEM_PROMPT = (
-    "You are a Bitcoin education assistant for BitPolito Academy. "
-    "Answer the student's question using ONLY the context provided below. "
-    "Be concise, accurate, and cite the source by its label (e.g. 'p. 3', 'Slide 5'). "
-    "If the answer is not in the context, say so explicitly."
-)
-
-
-def _call_llm(question: str, context: str) -> Optional[str]:
-    if not _OPENAI_API_KEY:
-        return None
-    try:
-        from langchain_openai import ChatOpenAI
-        from langchain.schema import HumanMessage, SystemMessage
-
-        # Set key via env so ChatOpenAI picks it up without a deprecated kwarg
-        os.environ.setdefault("OPENAI_API_KEY", _OPENAI_API_KEY)
-        llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.2)
-        messages = [
-            SystemMessage(content=_SYSTEM_PROMPT),
-            HumanMessage(content=f"Context:\n{context}\n\nQuestion: {question}"),
-        ]
-        response = llm.invoke(messages)
-        return str(response.content) if response.content else None  # type: ignore[return-value]
-    except Exception as exc:
-        logger.warning("LLM call failed: %s", exc)
-        return None
-
-
-# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 def answer(question: str, course_id: str) -> ChatResult:
-    """Retrieve relevant chunks and synthesise an answer.
+    """Send the question to the QVAC /query endpoint and return a ChatResult.
 
-    Falls back to returning raw context if no OpenAI key is configured
-    or if the LLM call fails.
+    retrieval_used is True only when the QVAC service returned at least one
+    source — empty sources means nothing was found in the workspace, not that
+    retrieval was skipped.
     """
-    hits = _retrieve(question, course_id)
-
-    if not hits:
+    try:
+        resp = httpx.post(
+            f"{_QVAC_SERVICE_URL}/query",
+            json={"question": question, "workspace": course_id, "topK": _TOP_K},
+            timeout=60.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPError as exc:
+        logger.warning("QVAC service unavailable: %s", exc)
         return ChatResult(
-            answer=(
-                "No relevant content was found for your question in this course. "
-                "The course materials may not yet be indexed."
-            ),
+            answer="The AI service is temporarily unavailable. Please try again later.",
             retrieval_used=False,
         )
 
-    citations = [
-        Citation(
-            label=h["label"],
-            section=h["section"] or None,
-            page=int(h["page"]) if h.get("page") else None,
-            slide=int(h["slide"]) if h.get("slide") else None,
-            text_snippet=h["text"][:250],
-        )
-        for h in hits
-    ]
-
-    context = _build_context(hits)
-    llm_answer = _call_llm(question, context)
-
-    if llm_answer:
-        answer_text = llm_answer
-    else:
-        # Graceful fallback: return the top retrieved chunk as plain context
-        answer_text = (
-            "Here are the most relevant passages from your course materials:\n\n"
-            + context
-        )
-
+    sources = data.get("sources", [])
     return ChatResult(
-        answer=answer_text,
-        citations=citations,
-        retrieval_used=True,
+        answer=data["answer"],
+        citations=[Citation(snippet=s["snippet"], score=s["score"]) for s in sources],
+        retrieval_used=bool(sources),
     )

--- a/services/ai/app/services/progress_service.py
+++ b/services/ai/app/services/progress_service.py
@@ -31,7 +31,8 @@ def _to_lesson_response(record) -> LessonProgressResponse:
 
 
 def _to_course_response(
-    record, lesson_count: int, completed_count: int
+    record, lesson_count: int, completed_count: int,
+    completed_lesson_ids: Optional[List[str]] = None,
 ) -> CourseProgressResponse:
     updated_at = record.updated_at
     if hasattr(updated_at, "isoformat"):
@@ -43,6 +44,7 @@ def _to_course_response(
         lesson_count=lesson_count,
         completed_count=completed_count,
         updated_at=str(updated_at),
+        completed_lesson_ids=completed_lesson_ids or [],
     )
 
 
@@ -125,9 +127,10 @@ def update_lesson_progress(
         if awarded:
             new_badges.append(awarded)
 
+    completed_ids = progress_repo.get_completed_lesson_ids(db, user_id, course_id)
     return ProgressUpdateResult(
         lesson_progress=_to_lesson_response(lesson_record),
-        course_progress=_to_course_response(course_record, lesson_count, completed_count),
+        course_progress=_to_course_response(course_record, lesson_count, completed_count, completed_ids),
         new_badges=new_badges,
     )
 
@@ -145,7 +148,8 @@ def get_course_progress(
             db, user_id, course_id, percent=0, status="not_started"
         )
 
-    return _to_course_response(record, lesson_count, completed_count)
+    completed_ids = progress_repo.get_completed_lesson_ids(db, user_id, course_id)
+    return _to_course_response(record, lesson_count, completed_count, completed_ids)
 
 
 def list_badges(db: Session) -> List[BadgeResponse]:

--- a/services/ai/app/services/study_service.py
+++ b/services/ai/app/services/study_service.py
@@ -1,0 +1,264 @@
+"""Study service — action-aware RAG dispatch with structured tracing.
+
+Retrieval is delegated to the QVAC Node.js service; generation uses
+langchain-openai when OPENAI_API_KEY is set, with graceful fallback to the
+QVAC raw answer when the key is absent or the call fails.
+
+Workspace = course_id, matching the convention in pipeline.py and chat_service.py.
+"""
+import dataclasses
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import httpx
+
+from app.schemas.study_schemas import (
+    STUDY_ACTION_REGISTRY,
+    StudyAction,
+)
+
+logger = logging.getLogger(__name__)
+
+_QVAC_SERVICE_URL = os.getenv("QVAC_SERVICE_URL", "http://localhost:3001")
+_TOP_K = int(os.getenv("RAG_TOP_K", "5"))
+_OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+_LLM_TIMEOUT = float(os.getenv("LLM_TIMEOUT_SECONDS", "30"))
+
+_qvac_client = httpx.AsyncClient(base_url=_QVAC_SERVICE_URL, timeout=60.0)
+
+_LANGCHAIN_AVAILABLE = False
+_ChatOpenAI = None
+_SystemMessage = None
+_HumanMessage = None
+
+try:
+    from langchain_openai import ChatOpenAI as _ChatOpenAI          # type: ignore[assignment]
+    from langchain_core.messages import (                            # type: ignore[assignment]
+        HumanMessage as _HumanMessage,
+        SystemMessage as _SystemMessage,
+    )
+    _LANGCHAIN_AVAILABLE = True
+except ImportError:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# System prompts per action
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPTS = {
+    StudyAction.EXPLAIN: (
+        "You are a Bitcoin education assistant for BitPolito Academy. "
+        "Using ONLY the provided context, explain the concept clearly in 2–4 paragraphs. "
+        "Cite sources where relevant (e.g. 'p. 7', 'Slide 5'). "
+        "If the answer is not in the context, say so explicitly."
+    ),
+    StudyAction.SUMMARIZE: (
+        "You are a Bitcoin education assistant. "
+        "Summarise the key points from the provided context as a numbered list of 5–8 concise bullet points. "
+        "Cover the main ideas without adding information not present in the context."
+    ),
+    StudyAction.OPEN_QUESTIONS: (
+        "Based on the provided context, generate exactly 5 open-ended questions "
+        "that would prompt a student to think critically about the material. "
+        "Output a numbered list of questions only — no answers."
+    ),
+    StudyAction.QUIZ: (
+        "Based on the provided context, create 4 multiple-choice questions for self-assessment. "
+        "For each question provide: the question, options A–D, and the correct answer. "
+        "Format each question as:\nQ: ...\nA) ...\nB) ...\nC) ...\nD) ...\nAnswer: [letter]"
+    ),
+    StudyAction.ORAL: (
+        "You are simulating an oral exam on Bitcoin material. "
+        "Generate 3 oral exam questions drawn from the provided context, "
+        "followed by a concise model answer for each. "
+        "Format each entry as:\nQ: ...\nModel answer: ..."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DispatchTrace:
+    request_id: str
+    course_id: str
+    action: str
+    query_length: int
+    retrieval_ran: bool
+    chunks_found: int
+    generation_ran: bool
+    fallback_used: bool
+    output_length: int
+    duration_ms: float
+    error: Optional[str]
+
+
+@dataclass
+class SourceChunk:
+    snippet: str
+    score: float
+    label: str = ""
+    page: int = 0
+    slide: int = 0
+    section: str = ""
+    doc_id: str = ""
+
+
+@dataclass
+class DispatchResult:
+    answer: str
+    citations: List[SourceChunk] = field(default_factory=list)
+    retrieval_used: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+async def _retrieve(question: str, course_id: str) -> tuple[str, List[SourceChunk]]:
+    """Call QVAC /query and return (raw_answer, sources)."""
+    try:
+        resp = await _qvac_client.post(
+            "/query",
+            json={"question": question, "workspace": course_id, "topK": _TOP_K},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        raw_answer = data.get("answer", "")
+        sources = [
+            SourceChunk(
+                snippet=s.get("snippet", ""),
+                score=s.get("score", 0.0),
+                label=s.get("label", ""),
+                page=s.get("page", 0),
+                slide=s.get("slide", 0),
+                section=s.get("section", ""),
+                doc_id=s.get("doc_id", ""),
+            )
+            for s in data.get("sources", [])
+        ]
+        return raw_answer, sources
+    except (httpx.HTTPError, ValueError, KeyError) as exc:
+        logger.warning("QVAC retrieval failed: %s", exc)
+        return "", []
+
+
+async def _generate(action: StudyAction, question: str, context: str) -> Optional[str]:
+    """Call OpenAI via langchain-openai with the action-specific system prompt.
+
+    Returns None when langchain-openai is unavailable or OPENAI_API_KEY is unset,
+    allowing the caller to fall back to the raw QVAC answer.
+    """
+    if not _LANGCHAIN_AVAILABLE or not _OPENAI_API_KEY:
+        return None
+
+    system_prompt = _SYSTEM_PROMPTS[action]
+    user_content = (
+        f"Context:\n{context}\n\nQuestion: {question}"
+        if context
+        else f"Question: {question}"
+    )
+
+    try:
+        llm = _ChatOpenAI(model="gpt-4o-mini", temperature=0.3, timeout=_LLM_TIMEOUT)  # type: ignore[call-arg]
+        response = await llm.ainvoke(
+            [_SystemMessage(content=system_prompt), _HumanMessage(content=user_content)]  # type: ignore[call-arg]
+        )
+        content = response.content
+        return content if isinstance(content, str) else str(content)
+    except Exception as exc:
+        logger.warning("LLM generation failed for action '%s': %s", action.value, exc)
+        return None
+
+
+async def _route(
+    question: str,
+    course_id: str,
+    action: StudyAction,
+    trace: DispatchTrace,
+) -> DispatchResult:
+    meta = STUDY_ACTION_REGISTRY[action]
+
+    # Step 1 — Retrieval
+    raw_answer = ""
+    sources: List[SourceChunk] = []
+    context = ""
+
+    if meta.retrieval_required:
+        trace.retrieval_ran = True
+        raw_answer, sources = await _retrieve(question, course_id)
+        trace.chunks_found = len(sources)
+        context = "\n\n---\n\n".join(
+            f"[{i + 1}] {s.snippet}" for i, s in enumerate(sources)
+        )
+
+    # Step 2 — retrieve-only shortcut
+    if not meta.generation_required:
+        return DispatchResult(
+            answer=raw_answer or "No relevant content found.",
+            citations=sources,
+            retrieval_used=bool(sources),
+        )
+
+    # Step 3 — Generation
+    generated = await _generate(action, question, context)
+    if generated is not None:
+        trace.generation_ran = True
+        answer = generated
+    else:
+        trace.fallback_used = True
+        answer = raw_answer or "No relevant content found."
+
+    return DispatchResult(answer=answer, citations=sources, retrieval_used=bool(sources))
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+async def dispatch(
+    question: str,
+    course_id: str,
+    action: StudyAction,
+) -> DispatchResult:
+    """Route a student query through retrieval and optional generation.
+
+    Emits a single structured JSON log line at INFO level on every call,
+    including when an exception is raised.  The request_id is not exposed
+    in the HTTP response — it lives only in the log.
+    """
+    request_id = str(uuid.uuid4())
+    started_at = time.perf_counter()
+
+    trace = DispatchTrace(
+        request_id=request_id,
+        course_id=course_id,
+        action=action.value,
+        query_length=len(question),
+        retrieval_ran=False,
+        chunks_found=0,
+        generation_ran=False,
+        fallback_used=False,
+        output_length=0,
+        duration_ms=0.0,
+        error=None,
+    )
+
+    try:
+        result = await _route(question, course_id, action, trace)
+        trace.output_length = len(result.answer)
+        return result
+    except Exception as exc:
+        trace.error = str(exc)
+        raise
+    finally:
+        trace.duration_ms = round((time.perf_counter() - started_at) * 1000, 2)
+        logger.info("dispatch_trace %s", json.dumps(dataclasses.asdict(trace)))

--- a/services/ai/app/workers/pipeline.py
+++ b/services/ai/app/workers/pipeline.py
@@ -18,9 +18,9 @@ import logging
 import os
 import sys
 import types
-import urllib.error
-import urllib.request
 from pathlib import Path
+
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -117,25 +117,16 @@ def _qvac_ingest(jsonl_path: Path, workspace: str, rebuild: bool = False) -> Non
     Non-blocking best-effort: logs a warning on failure so the pipeline
     continues even when the QVAC Node.js service is not running.
     """
-    payload = json.dumps({
-        "jsonlPath": str(jsonl_path),
-        "workspace": workspace,
-        "rebuild": rebuild,
-    }).encode()
-    req = urllib.request.Request(
-        f"{QVAC_SERVICE_URL}/ingest",
-        data=payload,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            logger.info("QVAC ingest accepted — workspace '%s', status %d", workspace, resp.status)
-    except urllib.error.URLError as exc:
-        # Service not running or unreachable — not a pipeline error.
-        logger.warning("QVAC service unavailable, skipping QVAC ingest: %s", exc.reason)
-    except Exception as exc:
-        logger.warning("QVAC ingest failed: %s", exc)
+        with httpx.Client(timeout=10) as client:
+            resp = client.post(
+                f"{QVAC_SERVICE_URL}/ingest",
+                json={"jsonlPath": str(jsonl_path), "workspace": workspace, "rebuild": rebuild},
+            )
+            resp.raise_for_status()
+            logger.info("QVAC ingest accepted — workspace '%s', status %d", workspace, resp.status_code)
+    except httpx.HTTPError as exc:
+        logger.warning("QVAC service unavailable, skipping QVAC ingest: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -268,7 +259,7 @@ def run(document_id: str, course_id: str, filename: str, file_path: str) -> None
             # Stage 3 — QVAC ingest (best-effort; pipeline succeeds even if skipped)
             # ------------------------------------------------------------------
             jsonl_path = _write_qvac_jsonl(para_chunks, document_id)
-            _qvac_ingest(jsonl_path, workspace=course_id, rebuild=True)
+            _qvac_ingest(jsonl_path, workspace=course_id, rebuild=False)
 
             # ------------------------------------------------------------------
             # Finalise DB record

--- a/services/ai/app/workers/pipeline.py
+++ b/services/ai/app/workers/pipeline.py
@@ -7,12 +7,19 @@ Import-conflict guard: registers 'services.ai.app.schemas.normalized_document'
 in sys.modules as an alias for the already-loaded 'app.schemas.normalized_document'
 so that ingester modules that use the longer import path get the *same* class
 objects as the rest of the FastAPI app.
+
+QVAC integration: after chunking, paragraph chunks are written to a JSONL file
+and posted to the QVAC Node.js service for embedding + HyperDB indexing.
+If the QVAC service is not running the pipeline still completes — ChromaDB
+remains the active query path until chat_service.py is switched over.
 """
 import json
 import logging
 import os
 import sys
 import types
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -27,6 +34,10 @@ _INGESTER_SRC = _MONOREPO_ROOT / "workers" / "python-ingester" / "src"
 
 CHROMA_DB_PATH = os.getenv("CHROMA_DB_PATH", str(_SERVICES_AI / "chroma_db"))
 UPLOADS_DIR = Path(os.getenv("UPLOADS_DIR", str(_SERVICES_AI / "uploads")))
+
+# JSONL files are written here so the QVAC service can read them by absolute path.
+QVAC_INGEST_DIR = Path(os.getenv("QVAC_INGEST_DIR", str(_SERVICES_AI / "qvac_ingest")))
+QVAC_SERVICE_URL = os.getenv("QVAC_SERVICE_URL", "http://localhost:3001")
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +90,52 @@ from app.db.models import CourseDocument, DocumentProcessingStage, DocumentStatu
 from app.db.session import get_db_context
 from app.repositories import document_repo
 from app.schemas.normalized_document import ChunkType, DocumentType
+
+
+# ---------------------------------------------------------------------------
+# QVAC helpers
+# ---------------------------------------------------------------------------
+
+def _write_qvac_jsonl(chunks: list, document_id: str) -> Path:
+    """Serialize paragraph chunks to a JSONL file readable by the QVAC service.
+
+    Uses course_id as workspace identifier, matching the convention in ingest.js.
+    Returns the absolute path written.
+    """
+    QVAC_INGEST_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = QVAC_INGEST_DIR / f"{document_id}_contingency.jsonl"
+    with out_path.open("w", encoding="utf-8") as f:
+        for chunk in chunks:
+            f.write(json.dumps(chunk.model_dump(mode="json")) + "\n")
+    logger.debug("Wrote %d chunks to %s", len(chunks), out_path)
+    return out_path
+
+
+def _qvac_ingest(jsonl_path: Path, workspace: str, rebuild: bool = False) -> None:
+    """POST the JSONL path to the QVAC service for embedding + HyperDB indexing.
+
+    Non-blocking best-effort: logs a warning on failure so the pipeline
+    continues even when the QVAC Node.js service is not running.
+    """
+    payload = json.dumps({
+        "jsonlPath": str(jsonl_path),
+        "workspace": workspace,
+        "rebuild": rebuild,
+    }).encode()
+    req = urllib.request.Request(
+        f"{QVAC_SERVICE_URL}/ingest",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            logger.info("QVAC ingest accepted — workspace '%s', status %d", workspace, resp.status)
+    except urllib.error.URLError as exc:
+        # Service not running or unreachable — not a pipeline error.
+        logger.warning("QVAC service unavailable, skipping QVAC ingest: %s", exc.reason)
+    except Exception as exc:
+        logger.warning("QVAC ingest failed: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +263,12 @@ def run(document_id: str, course_id: str, filename: str, file_path: str) -> None
                     metadatas=metadatas,
                 )
                 logger.info("Indexed %d vectors into ChromaDB at %s", len(ids), CHROMA_DB_PATH)
+
+            # ------------------------------------------------------------------
+            # Stage 3 — QVAC ingest (best-effort; pipeline succeeds even if skipped)
+            # ------------------------------------------------------------------
+            jsonl_path = _write_qvac_jsonl(para_chunks, document_id)
+            _qvac_ingest(jsonl_path, workspace=course_id, rebuild=True)
 
             # ------------------------------------------------------------------
             # Finalise DB record

--- a/services/ai/requirements.txt
+++ b/services/ai/requirements.txt
@@ -10,9 +10,6 @@ python-multipart==0.0.6
 httpx==0.25.2
 pytest==7.4.3
 pytest-asyncio==0.21.1
-langchain==0.2.17
-langchain-openai==0.1.25
-openai==1.51.2
 python-dotenv==1.0.0
 psycopg2-binary==2.9.9
 # Security packages

--- a/services/ai/requirements.txt
+++ b/services/ai/requirements.txt
@@ -21,3 +21,6 @@ pdfplumber==0.11.4
 python-pptx==0.6.23
 fastembed==0.2.6
 chromadb>=0.5.0
+# LLM generation — used by study_service for action-specific generation
+langchain>=0.3.0
+langchain-openai>=0.2.0

--- a/services/ai/tests/integration/test_chat_api.py
+++ b/services/ai/tests/integration/test_chat_api.py
@@ -1,10 +1,12 @@
 """Integration tests for POST /api/courses/{course_id}/chat.
 
-Strategy:
-- Auth is tested via JWT created with create_access_token (no real login needed).
-- ChromaDB and fastembed are patched to avoid slow ML inference in CI.
-- Empty-corpus path (no ChromaDB hits) is tested without any mocking.
+The chat endpoint now delegates to the QVAC Node.js service via httpx.post.
+All tests mock httpx.post so no QVAC service needs to be running.
+
+Citation schema changed from {label, section, page, slide, text_snippet}
+to {snippet, score} to match the QVAC /query response format.
 """
+import httpx
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +18,22 @@ from tests.conftest import make_course_with_lessons, make_user
 def _auth(user_id: str) -> dict:
     token = create_access_token(user_id, "u@test.com", "student")
     return {"Authorization": f"Bearer {token}"}
+
+
+def _qvac_ok(answer="Test answer.", sources=None) -> MagicMock:
+    """Build a mock httpx.Response for a successful QVAC /query call."""
+    resp = MagicMock()
+    resp.json.return_value = {"answer": answer, "sources": sources or []}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _qvac_empty() -> MagicMock:
+    """QVAC response when no content is indexed for the workspace."""
+    return _qvac_ok(
+        answer="No relevant content found for this question in the indexed course material.",
+        sources=[],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -69,17 +87,16 @@ def test_chat_rejects_missing_message(client, db):
 
 
 # ---------------------------------------------------------------------------
-# Empty corpus — no ChromaDB content → graceful fallback
+# Empty corpus — QVAC returns no sources
 # ---------------------------------------------------------------------------
 
 @pytest.mark.integration
-def test_chat_empty_corpus_returns_200_with_answer(client, db):
-    """When ChromaDB has no indexed content, the API still returns 200 with a human-readable answer."""
+def test_chat_empty_corpus_returns_200(client, db):
+    """When QVAC finds nothing, the endpoint still returns 200."""
     user = make_user(db)
     course, _ = make_course_with_lessons(db)
 
-    # Patch retrieval so it returns empty hits (simulates empty vector store)
-    with patch("app.services.chat_service._retrieve", return_value=[]):
+    with patch("httpx.post", return_value=_qvac_empty()):
         resp = client.post(
             f"/api/courses/{course.id}/chat",
             json={"message": "What is a UTXO?"},
@@ -88,7 +105,6 @@ def test_chat_empty_corpus_returns_200_with_answer(client, db):
 
     assert resp.status_code == 200
     data = resp.json()
-    assert "answer" in data
     assert isinstance(data["answer"], str)
     assert len(data["answer"]) > 0
     assert data["retrieval_used"] is False
@@ -97,11 +113,11 @@ def test_chat_empty_corpus_returns_200_with_answer(client, db):
 
 @pytest.mark.integration
 def test_chat_empty_corpus_answer_is_informative(client, db):
-    """Empty-corpus answer should tell the student material isn't indexed yet."""
+    """Empty-corpus answer must tell the student materials aren't available."""
     user = make_user(db)
     course, _ = make_course_with_lessons(db)
 
-    with patch("app.services.chat_service._retrieve", return_value=[]):
+    with patch("httpx.post", return_value=_qvac_empty()):
         resp = client.post(
             f"/api/courses/{course.id}/chat",
             json={"message": "Explain the Merkle tree."},
@@ -109,12 +125,11 @@ def test_chat_empty_corpus_answer_is_informative(client, db):
         )
 
     answer = resp.json()["answer"].lower()
-    # Should mention no content / not indexed
     assert any(kw in answer for kw in ["no relevant", "not yet", "not found", "materials"])
 
 
 # ---------------------------------------------------------------------------
-# Successful retrieval path — with mocked ChromaDB hits
+# Successful retrieval — QVAC returns sources
 # ---------------------------------------------------------------------------
 
 @pytest.mark.integration
@@ -122,96 +137,44 @@ def test_chat_returns_citations_on_hit(client, db):
     user = make_user(db)
     course, _ = make_course_with_lessons(db)
 
-    fake_hits = [
-        {
-            "id": "chunk-1",
-            "text": "A UTXO is an unspent transaction output.",
-            "distance": 0.1,
-            "label": "p. 3",
-            "section": "Transactions",
-            "page": 3,
-            "slide": None,
-        }
-    ]
-
-    with patch("app.services.chat_service._retrieve", return_value=fake_hits):
-        with patch("app.services.chat_service._call_llm", return_value="A UTXO is an unspent output."):
-            resp = client.post(
-                f"/api/courses/{course.id}/chat",
-                json={"message": "What is a UTXO?"},
-                headers=_auth(user.id),
-            )
+    with patch("httpx.post", return_value=_qvac_ok(
+        answer="A UTXO is an unspent transaction output.",
+        sources=[{"snippet": "A UTXO is an unspent transaction output.", "score": 0.9}],
+    )):
+        resp = client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "What is a UTXO?"},
+            headers=_auth(user.id),
+        )
 
     assert resp.status_code == 200
     data = resp.json()
     assert data["retrieval_used"] is True
     assert len(data["citations"]) == 1
     c = data["citations"][0]
-    assert c["label"] == "p. 3"
-    assert c["page"] == 3
-    assert "UTXO" in c["text_snippet"]
+    assert "UTXO" in c["snippet"]
+    assert isinstance(c["score"], float)
 
 
 @pytest.mark.integration
-def test_chat_answer_comes_from_llm_when_available(client, db):
+def test_chat_answer_comes_from_qvac_service(client, db):
+    """The answer field must be exactly what the QVAC service returned."""
     user = make_user(db)
     course, _ = make_course_with_lessons(db)
 
-    fake_hits = [
-        {
-            "id": "chunk-1",
-            "text": "Bitcoin uses proof-of-work.",
-            "distance": 0.05,
-            "label": "p. 1",
-            "section": "Consensus",
-            "page": 1,
-            "slide": None,
-        }
-    ]
-
-    with patch("app.services.chat_service._retrieve", return_value=fake_hits):
-        with patch("app.services.chat_service._call_llm", return_value="Proof-of-work is a consensus mechanism."):
-            resp = client.post(
-                f"/api/courses/{course.id}/chat",
-                json={"message": "Explain proof of work."},
-                headers=_auth(user.id),
-            )
+    expected = "Proof-of-work is a consensus mechanism."
+    with patch("httpx.post", return_value=_qvac_ok(
+        answer=expected,
+        sources=[{"snippet": "Bitcoin uses proof-of-work.", "score": 0.95}],
+    )):
+        resp = client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "Explain proof of work."},
+            headers=_auth(user.id),
+        )
 
     assert resp.status_code == 200
-    assert resp.json()["answer"] == "Proof-of-work is a consensus mechanism."
-
-
-@pytest.mark.integration
-def test_chat_fallback_when_llm_returns_none(client, db):
-    """When _call_llm returns None, the raw context is returned instead."""
-    user = make_user(db)
-    course, _ = make_course_with_lessons(db)
-
-    fake_hits = [
-        {
-            "id": "chunk-1",
-            "text": "Satoshi Nakamoto published the Bitcoin whitepaper in 2008.",
-            "distance": 0.2,
-            "label": "Slide 1",
-            "section": None,
-            "page": None,
-            "slide": 1,
-        }
-    ]
-
-    with patch("app.services.chat_service._retrieve", return_value=fake_hits):
-        with patch("app.services.chat_service._call_llm", return_value=None):
-            resp = client.post(
-                f"/api/courses/{course.id}/chat",
-                json={"message": "Who is Satoshi?"},
-                headers=_auth(user.id),
-            )
-
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["retrieval_used"] is True
-    # Fallback includes raw context
-    assert "Satoshi" in data["answer"] or "relevant passages" in data["answer"].lower()
+    assert resp.json()["answer"] == expected
 
 
 @pytest.mark.integration
@@ -219,22 +182,118 @@ def test_chat_multiple_citations(client, db):
     user = make_user(db)
     course, _ = make_course_with_lessons(db)
 
-    fake_hits = [
-        {"id": f"chunk-{i}", "text": f"Content {i}.", "distance": 0.1 * i,
-         "label": f"p. {i}", "section": f"Section {i}", "page": i, "slide": None}
-        for i in range(1, 4)
+    sources = [
+        {"snippet": f"Content about topic {i}.", "score": round(0.9 - i * 0.05, 2)}
+        for i in range(3)
     ]
-
-    with patch("app.services.chat_service._retrieve", return_value=fake_hits):
-        with patch("app.services.chat_service._call_llm", return_value="Combined answer."):
-            resp = client.post(
-                f"/api/courses/{course.id}/chat",
-                json={"message": "Tell me everything."},
-                headers=_auth(user.id),
-            )
+    with patch("httpx.post", return_value=_qvac_ok(answer="Combined answer.", sources=sources)):
+        resp = client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "Tell me everything."},
+            headers=_auth(user.id),
+        )
 
     assert resp.status_code == 200
     assert len(resp.json()["citations"]) == 3
+
+
+@pytest.mark.integration
+def test_chat_citation_scores_are_preserved(client, db):
+    """Score values returned by QVAC must appear unchanged in the response."""
+    user = make_user(db)
+    course, _ = make_course_with_lessons(db)
+
+    sources = [
+        {"snippet": "First chunk.", "score": 0.92},
+        {"snippet": "Second chunk.", "score": 0.77},
+    ]
+    with patch("httpx.post", return_value=_qvac_ok(answer="Answer.", sources=sources)):
+        resp = client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "Question."},
+            headers=_auth(user.id),
+        )
+
+    citations = resp.json()["citations"]
+    assert citations[0]["score"] == 0.92
+    assert citations[1]["score"] == 0.77
+
+
+# ---------------------------------------------------------------------------
+# QVAC service unavailable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_chat_qvac_service_unavailable_returns_200(client, db):
+    """When the QVAC service is down, the endpoint returns 200 with an error message."""
+    user = make_user(db)
+    course, _ = make_course_with_lessons(db)
+
+    with patch("httpx.post", side_effect=httpx.HTTPError("connection refused")):
+        resp = client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "What is Bitcoin?"},
+            headers=_auth(user.id),
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["retrieval_used"] is False
+    assert data["citations"] == []
+    assert "unavailable" in data["answer"].lower()
+
+
+@pytest.mark.integration
+def test_chat_qvac_timeout_returns_200(client, db):
+    user = make_user(db)
+    course, _ = make_course_with_lessons(db)
+
+    with patch("httpx.post", side_effect=httpx.TimeoutException("read timeout")):
+        resp = client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "What is Bitcoin?"},
+            headers=_auth(user.id),
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["retrieval_used"] is False
+
+
+# ---------------------------------------------------------------------------
+# QVAC call parameters — verify the service receives correct inputs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_chat_sends_course_id_as_workspace(client, db):
+    """httpx.post must be called with workspace=course_id."""
+    user = make_user(db)
+    course, _ = make_course_with_lessons(db)
+
+    with patch("httpx.post", return_value=_qvac_ok()) as mock_post:
+        client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "Question."},
+            headers=_auth(user.id),
+        )
+
+    call_kwargs = mock_post.call_args[1]
+    assert call_kwargs["json"]["workspace"] == course.id
+
+
+@pytest.mark.integration
+def test_chat_sends_question_in_payload(client, db):
+    user = make_user(db)
+    course, _ = make_course_with_lessons(db)
+
+    with patch("httpx.post", return_value=_qvac_ok()) as mock_post:
+        client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "What is a Merkle root?"},
+            headers=_auth(user.id),
+        )
+
+    call_kwargs = mock_post.call_args[1]
+    assert call_kwargs["json"]["question"] == "What is a Merkle root?"
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +305,7 @@ def test_chat_response_has_required_fields(client, db):
     user = make_user(db)
     course, _ = make_course_with_lessons(db)
 
-    with patch("app.services.chat_service._retrieve", return_value=[]):
+    with patch("httpx.post", return_value=_qvac_empty()):
         resp = client.post(
             f"/api/courses/{course.id}/chat",
             json={"message": "Hello?"},
@@ -259,3 +318,25 @@ def test_chat_response_has_required_fields(client, db):
     assert isinstance(data["answer"], str)
     assert isinstance(data["citations"], list)
     assert isinstance(data["retrieval_used"], bool)
+
+
+@pytest.mark.integration
+def test_chat_citation_has_snippet_and_score_fields(client, db):
+    """Each citation must have exactly snippet and score."""
+    user = make_user(db)
+    course, _ = make_course_with_lessons(db)
+
+    with patch("httpx.post", return_value=_qvac_ok(
+        answer="Answer.",
+        sources=[{"snippet": "Some Bitcoin content.", "score": 0.88}],
+    )):
+        resp = client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "Explain Bitcoin."},
+            headers=_auth(user.id),
+        )
+
+    citation = resp.json()["citations"][0]
+    assert set(citation.keys()) == {"snippet", "score"}
+    assert isinstance(citation["snippet"], str)
+    assert isinstance(citation["score"], float)

--- a/services/ai/tests/integration/test_pipeline_e2e.py
+++ b/services/ai/tests/integration/test_pipeline_e2e.py
@@ -1,10 +1,15 @@
 """End-to-end pipeline integration tests using real fixture files.
 
 These tests exercise the full chain:
-  PDF/PPTX → StructuralParser → Chunker → ChromaDB (temp dir)
+  PDF/PPTX → StructuralParser → Chunker → ChromaDB (temp dir) → QVAC ingest
 
-The pipeline.run() function is tested with a temp ChromaDB and a real DB session
-(in-memory SQLite via conftest). fastembed and chromadb must be installed.
+The pipeline.run() function is tested with a temp ChromaDB, a temp QVAC ingest
+directory, and a real DB session (in-memory SQLite via conftest).
+fastembed and chromadb must be installed.
+
+_qvac_ingest is patched in _run_pipeline() to avoid network calls — the QVAC
+service doesn't need to be running for these tests. QVAC-specific assertions
+(JSONL content, call args) are in dedicated tests that set up their own context.
 
 Marked @pytest.mark.slow — excluded from the default fast test run.
 """
@@ -43,7 +48,12 @@ def _try_import(module_name: str):
 # ---------------------------------------------------------------------------
 
 def _run_pipeline(db, file_path: Path, course_id: str, filename: str) -> tuple:
-    """Run pipeline.run() with a temp ChromaDB and return (doc_id, doc_record)."""
+    """Run pipeline.run() with isolated ChromaDB and QVAC dirs.
+
+    _qvac_ingest is patched so no HTTP call is made to the QVAC service.
+    The JSONL file is still written to a temp directory (tests can inspect it
+    separately if needed). Returns (doc_id, doc_record).
+    """
     _try_import("fastembed")
     _try_import("chromadb")
 
@@ -51,7 +61,6 @@ def _run_pipeline(db, file_path: Path, course_id: str, filename: str) -> tuple:
 
     doc_id = str(uuid.uuid4())
 
-    # Create a CourseDocument record manually
     from app.db.models import CourseDocument, DocumentProcessingStage, DocumentStatus
     doc = CourseDocument(
         id=doc_id,
@@ -66,11 +75,10 @@ def _run_pipeline(db, file_path: Path, course_id: str, filename: str) -> tuple:
     db.commit()
 
     with tempfile.TemporaryDirectory() as tmp_chroma:
-        with patch.dict(os.environ, {"CHROMA_DB_PATH": tmp_chroma}):
-            # Reload chroma path in pipeline module (it reads env at import time)
+        with tempfile.TemporaryDirectory() as tmp_qvac:
             pipeline_mod.CHROMA_DB_PATH = tmp_chroma
+            pipeline_mod.QVAC_INGEST_DIR = Path(tmp_qvac)
 
-            # Copy fixture to a temp upload path so pipeline.run() can read it
             with tempfile.NamedTemporaryFile(
                 suffix=Path(filename).suffix, delete=False
             ) as tmp_file:
@@ -78,20 +86,21 @@ def _run_pipeline(db, file_path: Path, course_id: str, filename: str) -> tuple:
                 tmp_path = tmp_file.name
 
             try:
-                # Use a real DB context: patch get_db_context to yield our session
                 from contextlib import contextmanager
 
                 @contextmanager
                 def _fake_db_ctx():
                     yield db
 
-                with patch("app.workers.pipeline.get_db_context", _fake_db_ctx):
-                    pipeline_mod.run(
-                        document_id=doc_id,
-                        course_id=course_id,
-                        filename=filename,
-                        file_path=tmp_path,
-                    )
+                # Patch _qvac_ingest to avoid requiring the QVAC service to be running
+                with patch("app.workers.pipeline._qvac_ingest"):
+                    with patch("app.workers.pipeline.get_db_context", _fake_db_ctx):
+                        pipeline_mod.run(
+                            document_id=doc_id,
+                            course_id=course_id,
+                            filename=filename,
+                            file_path=tmp_path,
+                        )
             finally:
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
@@ -340,3 +349,224 @@ def test_pipeline_unknown_document_id_does_not_raise(client, db):
             filename="x.pdf",
             file_path="/tmp/x.pdf",
         )
+
+
+# ---------------------------------------------------------------------------
+# QVAC integration — verifies the JSONL write + _qvac_ingest call
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_pipeline_writes_qvac_jsonl_for_pdf(client, db):
+    """After a successful run, a JSONL file must exist in QVAC_INGEST_DIR."""
+    _skip_if_missing(PDF_PATH)
+    _try_import("fastembed")
+    _try_import("chromadb")
+
+    import app.workers.pipeline as pipeline_mod
+    from contextlib import contextmanager
+    from app.db.models import CourseDocument, DocumentProcessingStage, DocumentStatus
+
+    course, _ = make_course_with_lessons(db)
+    doc_id = str(uuid.uuid4())
+    doc = CourseDocument(
+        id=doc_id, course_id=course.id, filename="bitcoin_technical_document.pdf",
+        status=DocumentStatus.PROCESSING,
+        processing_stage=DocumentProcessingStage.UPLOADING,
+        size=PDF_PATH.stat().st_size, mime_type="application/pdf",
+    )
+    db.add(doc)
+    db.commit()
+
+    with tempfile.TemporaryDirectory() as tmp_chroma:
+        with tempfile.TemporaryDirectory() as tmp_qvac:
+            pipeline_mod.CHROMA_DB_PATH = tmp_chroma
+            pipeline_mod.QVAC_INGEST_DIR = Path(tmp_qvac)
+
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+                f.write(PDF_PATH.read_bytes())
+                tmp_path = f.name
+
+            try:
+                @contextmanager
+                def _fake_db_ctx():
+                    yield db
+
+                with patch("app.workers.pipeline._qvac_ingest"):
+                    with patch("app.workers.pipeline.get_db_context", _fake_db_ctx):
+                        pipeline_mod.run(
+                            document_id=doc_id, course_id=course.id,
+                            filename="bitcoin_technical_document.pdf", file_path=tmp_path,
+                        )
+            finally:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+
+            expected_jsonl = Path(tmp_qvac) / f"{doc_id}_contingency.jsonl"
+            assert expected_jsonl.exists(), "JSONL file not written to QVAC_INGEST_DIR"
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_pipeline_qvac_jsonl_contains_only_paragraph_chunks(client, db):
+    """JSONL written by the pipeline must contain only paragraph-type chunks."""
+    _skip_if_missing(PDF_PATH)
+    _try_import("fastembed")
+    _try_import("chromadb")
+
+    import app.workers.pipeline as pipeline_mod
+    from contextlib import contextmanager
+    from app.db.models import CourseDocument, DocumentProcessingStage, DocumentStatus
+
+    course, _ = make_course_with_lessons(db)
+    doc_id = str(uuid.uuid4())
+    doc = CourseDocument(
+        id=doc_id, course_id=course.id, filename="bitcoin_technical_document.pdf",
+        status=DocumentStatus.PROCESSING,
+        processing_stage=DocumentProcessingStage.UPLOADING,
+        size=PDF_PATH.stat().st_size, mime_type="application/pdf",
+    )
+    db.add(doc)
+    db.commit()
+
+    with tempfile.TemporaryDirectory() as tmp_chroma:
+        with tempfile.TemporaryDirectory() as tmp_qvac:
+            pipeline_mod.CHROMA_DB_PATH = tmp_chroma
+            pipeline_mod.QVAC_INGEST_DIR = Path(tmp_qvac)
+
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+                f.write(PDF_PATH.read_bytes())
+                tmp_path = f.name
+
+            try:
+                @contextmanager
+                def _fake_db_ctx():
+                    yield db
+
+                with patch("app.workers.pipeline._qvac_ingest"):
+                    with patch("app.workers.pipeline.get_db_context", _fake_db_ctx):
+                        pipeline_mod.run(
+                            document_id=doc_id, course_id=course.id,
+                            filename="bitcoin_technical_document.pdf", file_path=tmp_path,
+                        )
+            finally:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+
+            jsonl_path = Path(tmp_qvac) / f"{doc_id}_contingency.jsonl"
+            rows = [json.loads(l) for l in jsonl_path.read_text().splitlines()]
+            assert len(rows) > 0
+            for row in rows:
+                assert row["chunk_type"] == "paragraph", (
+                    f"non-paragraph chunk found in QVAC JSONL: {row['chunk_type']}"
+                )
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_pipeline_qvac_ingest_called_with_course_id_as_workspace(client, db):
+    """_qvac_ingest must be called with workspace equal to course_id."""
+    _skip_if_missing(PDF_PATH)
+    _try_import("fastembed")
+    _try_import("chromadb")
+
+    import app.workers.pipeline as pipeline_mod
+    from contextlib import contextmanager
+    from app.db.models import CourseDocument, DocumentProcessingStage, DocumentStatus
+
+    course, _ = make_course_with_lessons(db)
+    doc_id = str(uuid.uuid4())
+    doc = CourseDocument(
+        id=doc_id, course_id=course.id, filename="bitcoin_technical_document.pdf",
+        status=DocumentStatus.PROCESSING,
+        processing_stage=DocumentProcessingStage.UPLOADING,
+        size=PDF_PATH.stat().st_size, mime_type="application/pdf",
+    )
+    db.add(doc)
+    db.commit()
+
+    with tempfile.TemporaryDirectory() as tmp_chroma:
+        with tempfile.TemporaryDirectory() as tmp_qvac:
+            pipeline_mod.CHROMA_DB_PATH = tmp_chroma
+            pipeline_mod.QVAC_INGEST_DIR = Path(tmp_qvac)
+
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+                f.write(PDF_PATH.read_bytes())
+                tmp_path = f.name
+
+            try:
+                @contextmanager
+                def _fake_db_ctx():
+                    yield db
+
+                with patch("app.workers.pipeline._qvac_ingest") as mock_qvac:
+                    with patch("app.workers.pipeline.get_db_context", _fake_db_ctx):
+                        pipeline_mod.run(
+                            document_id=doc_id, course_id=course.id,
+                            filename="bitcoin_technical_document.pdf", file_path=tmp_path,
+                        )
+            finally:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+
+    mock_qvac.assert_called_once()
+    _, call_kwargs = mock_qvac.call_args
+    assert call_kwargs["workspace"] == course.id
+    assert call_kwargs["rebuild"] is True
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_pipeline_qvac_jsonl_has_required_fields(client, db):
+    """Each row in the QVAC JSONL must carry the fields that ingest.js reads."""
+    _skip_if_missing(PDF_PATH)
+    _try_import("fastembed")
+    _try_import("chromadb")
+
+    import app.workers.pipeline as pipeline_mod
+    from contextlib import contextmanager
+    from app.db.models import CourseDocument, DocumentProcessingStage, DocumentStatus
+
+    course, _ = make_course_with_lessons(db)
+    doc_id = str(uuid.uuid4())
+    doc = CourseDocument(
+        id=doc_id, course_id=course.id, filename="bitcoin_technical_document.pdf",
+        status=DocumentStatus.PROCESSING,
+        processing_stage=DocumentProcessingStage.UPLOADING,
+        size=PDF_PATH.stat().st_size, mime_type="application/pdf",
+    )
+    db.add(doc)
+    db.commit()
+
+    required_fields = {"chunk_id", "doc_id", "course_id", "chunk_type", "text"}
+
+    with tempfile.TemporaryDirectory() as tmp_chroma:
+        with tempfile.TemporaryDirectory() as tmp_qvac:
+            pipeline_mod.CHROMA_DB_PATH = tmp_chroma
+            pipeline_mod.QVAC_INGEST_DIR = Path(tmp_qvac)
+
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+                f.write(PDF_PATH.read_bytes())
+                tmp_path = f.name
+
+            try:
+                @contextmanager
+                def _fake_db_ctx():
+                    yield db
+
+                with patch("app.workers.pipeline._qvac_ingest"):
+                    with patch("app.workers.pipeline.get_db_context", _fake_db_ctx):
+                        pipeline_mod.run(
+                            document_id=doc_id, course_id=course.id,
+                            filename="bitcoin_technical_document.pdf", file_path=tmp_path,
+                        )
+            finally:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+
+            jsonl_path = Path(tmp_qvac) / f"{doc_id}_contingency.jsonl"
+            rows = [json.loads(l) for l in jsonl_path.read_text().splitlines()]
+            assert len(rows) > 0
+            for row in rows:
+                missing = required_fields - row.keys()
+                assert not missing, f"JSONL row missing fields: {missing}"

--- a/services/ai/tests/integration/test_wiring.py
+++ b/services/ai/tests/integration/test_wiring.py
@@ -1,0 +1,185 @@
+"""Step 8 wiring tests — verify that course_id flows correctly as the QVAC
+workspace through both the upload and chat paths.
+
+This is the contract the two paths must maintain: documents indexed under a
+course_id workspace during ingest are retrievable when a student queries that
+same course's chat endpoint. Breaking this invariant silently would mean the
+RAG pipeline returns results from the wrong course, or nothing at all.
+
+Test need to cover LLM query path and document upload path, and verify that both use the same course_id workspace when calling QVAC. Also verify that different courses use different workspaces, and that the chat endpoint correctly forwards the full QVAC response to the client.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.config import create_access_token
+from tests.conftest import make_course_with_lessons, make_user
+
+
+def _auth(user_id: str) -> dict:
+    token = create_access_token(user_id, "u@test.com", "student")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _qvac_ok(answer="Test answer.", sources=None) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = {"answer": answer, "sources": sources or []}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Core workspace contract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_upload_and_chat_use_same_qvac_workspace(client, db):
+    """The QVAC workspace for ingest and query must both equal course_id.
+
+    If either side uses a different identifier, documents indexed during upload
+    will not be found at query time — the workspace is the only key linking the
+    two operations.
+    """
+    course, _ = make_course_with_lessons(db)
+    user = make_user(db)
+
+    with patch("app.workers.pipeline.run") as mock_pipeline:
+        resp = client.post(
+            f"/api/courses/{course.id}/documents",
+            files={"file": ("doc.pdf", b"%PDF fake", "application/pdf")},
+        )
+    assert resp.status_code == 201
+    upload_course_id = mock_pipeline.call_args[1]["course_id"]
+
+    with patch("httpx.post", return_value=_qvac_ok()) as mock_qvac:
+        client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "What is Bitcoin?"},
+            headers=_auth(user.id),
+        )
+    chat_workspace = mock_qvac.call_args[1]["json"]["workspace"]
+
+    assert upload_course_id == course.id
+    assert chat_workspace == course.id
+    assert upload_course_id == chat_workspace
+
+
+@pytest.mark.integration
+def test_different_courses_use_different_workspaces(client, db):
+    """Two courses must map to different QVAC workspaces — no cross-course leakage."""
+    course_a, _ = make_course_with_lessons(db)
+    course_b, _ = make_course_with_lessons(db)
+    user = make_user(db)
+
+    with patch("httpx.post", return_value=_qvac_ok()) as mock_a:
+        client.post(
+            f"/api/courses/{course_a.id}/chat",
+            json={"message": "Question about course A."},
+            headers=_auth(user.id),
+        )
+    workspace_a = mock_a.call_args[1]["json"]["workspace"]
+
+    with patch("httpx.post", return_value=_qvac_ok()) as mock_b:
+        client.post(
+            f"/api/courses/{course_b.id}/chat",
+            json={"message": "Question about course B."},
+            headers=_auth(user.id),
+        )
+    workspace_b = mock_b.call_args[1]["json"]["workspace"]
+
+    assert workspace_a != workspace_b
+    assert workspace_a == course_a.id
+    assert workspace_b == course_b.id
+
+
+# ---------------------------------------------------------------------------
+# Upload path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_pipeline_receives_correct_args_from_upload_api(client, db):
+    """Upload API must forward document_id, course_id, filename, and file_path to pipeline.run."""
+    course, _ = make_course_with_lessons(db)
+
+    with patch("app.workers.pipeline.run") as mock_pipeline:
+        resp = client.post(
+            f"/api/courses/{course.id}/documents",
+            files={"file": ("lecture.pdf", b"%PDF fake", "application/pdf")},
+        )
+
+    assert resp.status_code == 201
+    doc_id = resp.json()["id"]
+    kwargs = mock_pipeline.call_args[1]
+
+    assert kwargs["document_id"] == doc_id
+    assert kwargs["course_id"] == course.id
+    assert kwargs["filename"] == "lecture.pdf"
+    assert "file_path" in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Chat path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_chat_posts_to_qvac_query_endpoint(client, db):
+    """The chat handler must POST to /query on the QVAC service, not any other path."""
+    course, _ = make_course_with_lessons(db)
+    user = make_user(db)
+
+    with patch("httpx.post", return_value=_qvac_ok()) as mock_post:
+        client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "Explain mining."},
+            headers=_auth(user.id),
+        )
+
+    called_url = mock_post.call_args[0][0]
+    assert called_url.endswith("/query"), f"Expected /query endpoint, got: {called_url}"
+
+
+@pytest.mark.integration
+def test_chat_answer_and_citations_flow_from_qvac_to_client(client, db):
+    """The full response from QVAC /query must reach the HTTP client unchanged."""
+    course, _ = make_course_with_lessons(db)
+    user = make_user(db)
+
+    expected_answer = "The blockchain is a distributed ledger."
+    sources = [
+        {"snippet": "A blockchain records transactions.", "score": 0.95},
+        {"snippet": "Each block links to the previous one.", "score": 0.88},
+    ]
+
+    with patch("httpx.post", return_value=_qvac_ok(answer=expected_answer, sources=sources)):
+        resp = client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "What is blockchain?"},
+            headers=_auth(user.id),
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"] == expected_answer
+    assert data["retrieval_used"] is True
+    assert len(data["citations"]) == 2
+    assert data["citations"][0]["score"] == 0.95
+    assert data["citations"][1]["snippet"] == "Each block links to the previous one."
+
+
+@pytest.mark.integration
+def test_chat_topk_is_forwarded_to_qvac(client, db):
+    """The QVAC /query call must include a topK parameter."""
+    course, _ = make_course_with_lessons(db)
+    user = make_user(db)
+
+    with patch("httpx.post", return_value=_qvac_ok()) as mock_post:
+        client.post(
+            f"/api/courses/{course.id}/chat",
+            json={"message": "Question."},
+            headers=_auth(user.id),
+        )
+
+    payload = mock_post.call_args[1]["json"]
+    assert "topK" in payload
+    assert isinstance(payload["topK"], int)
+    assert payload["topK"] > 0

--- a/services/ai/tests/unit/test_qvac_pipeline.py
+++ b/services/ai/tests/unit/test_qvac_pipeline.py
@@ -1,0 +1,189 @@
+"""Unit tests for the QVAC integration in pipeline.py.
+
+Covers _write_qvac_jsonl and _qvac_ingest without loading fastembed,
+chromadb, or any ML model. All I/O and network calls are mocked.
+"""
+import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.workers.pipeline as pipeline_mod
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _chunk(text="Bitcoin uses UTXO.", doc_id="DOC1", course_id="COURSE1"):
+    """Minimal DocumentChunk-like mock with a working model_dump()."""
+    c = MagicMock()
+    c.model_dump.return_value = {
+        "chunk_id": "abc-123",
+        "doc_id": doc_id,
+        "course_id": course_id,
+        "chunk_type": "paragraph",
+        "text": text,
+        "citation_label": "p. 1",
+        "citation_page": 1,
+        "citation_slide": None,
+        "citation_section": "Intro",
+        "parent_chunk_id": None,
+        "tags": [],
+        "prerequisites": [],
+    }
+    return c
+
+
+def _mock_urlopen_response(status=200):
+    """Context-manager mock that mimics the urllib response object."""
+    resp = MagicMock()
+    resp.status = status
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _write_qvac_jsonl
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_write_qvac_jsonl_creates_file(tmp_path):
+    with patch.object(pipeline_mod, "QVAC_INGEST_DIR", tmp_path):
+        out = pipeline_mod._write_qvac_jsonl([_chunk()], "DOC1")
+    assert out.exists()
+    assert out.name == "DOC1_contingency.jsonl"
+
+
+@pytest.mark.unit
+def test_write_qvac_jsonl_returns_absolute_path(tmp_path):
+    with patch.object(pipeline_mod, "QVAC_INGEST_DIR", tmp_path):
+        out = pipeline_mod._write_qvac_jsonl([_chunk()], "DOC1")
+    assert out.is_absolute()
+
+
+@pytest.mark.unit
+def test_write_qvac_jsonl_one_line_per_chunk(tmp_path):
+    chunks = [_chunk(text=f"chunk {i}") for i in range(4)]
+    with patch.object(pipeline_mod, "QVAC_INGEST_DIR", tmp_path):
+        out = pipeline_mod._write_qvac_jsonl(chunks, "DOC1")
+    lines = [l for l in out.read_text().splitlines() if l.strip()]
+    assert len(lines) == 4
+
+
+@pytest.mark.unit
+def test_write_qvac_jsonl_each_line_is_valid_json(tmp_path):
+    chunks = [_chunk(text=f"chunk {i}") for i in range(3)]
+    with patch.object(pipeline_mod, "QVAC_INGEST_DIR", tmp_path):
+        out = pipeline_mod._write_qvac_jsonl(chunks, "DOC1")
+    for line in out.read_text().splitlines():
+        obj = json.loads(line)
+        assert isinstance(obj, dict)
+
+
+@pytest.mark.unit
+def test_write_qvac_jsonl_content_matches_model_dump(tmp_path):
+    c = _chunk(text="Proof-of-work secures the chain.", doc_id="DOCX", course_id="C42")
+    with patch.object(pipeline_mod, "QVAC_INGEST_DIR", tmp_path):
+        out = pipeline_mod._write_qvac_jsonl([c], "DOCX")
+    row = json.loads(out.read_text().strip())
+    assert row["text"] == "Proof-of-work secures the chain."
+    assert row["doc_id"] == "DOCX"
+    assert row["course_id"] == "C42"
+
+
+@pytest.mark.unit
+def test_write_qvac_jsonl_empty_input_creates_empty_file(tmp_path):
+    with patch.object(pipeline_mod, "QVAC_INGEST_DIR", tmp_path):
+        out = pipeline_mod._write_qvac_jsonl([], "DOC2")
+    assert out.read_text() == ""
+
+
+@pytest.mark.unit
+def test_write_qvac_jsonl_creates_parent_directories(tmp_path):
+    nested = tmp_path / "a" / "b" / "c"
+    assert not nested.exists()
+    with patch.object(pipeline_mod, "QVAC_INGEST_DIR", nested):
+        pipeline_mod._write_qvac_jsonl([_chunk()], "DOC3")
+    assert nested.exists()
+
+
+# ---------------------------------------------------------------------------
+# _qvac_ingest — request construction
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_qvac_ingest_posts_to_ingest_route(tmp_path):
+    jsonl = tmp_path / "doc.jsonl"
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_response()) as mock_open:
+        with patch.object(pipeline_mod, "QVAC_SERVICE_URL", "http://localhost:3001"):
+            pipeline_mod._qvac_ingest(jsonl, "COURSE1")
+    req = mock_open.call_args[0][0]
+    assert req.full_url == "http://localhost:3001/ingest"
+    assert req.method == "POST"
+
+
+@pytest.mark.unit
+def test_qvac_ingest_payload_contains_workspace(tmp_path):
+    jsonl = tmp_path / "doc.jsonl"
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_response()) as mock_open:
+        pipeline_mod._qvac_ingest(jsonl, "BTC_2025")
+    body = json.loads(mock_open.call_args[0][0].data)
+    assert body["workspace"] == "BTC_2025"
+
+
+@pytest.mark.unit
+def test_qvac_ingest_payload_contains_absolute_jsonl_path(tmp_path):
+    jsonl = tmp_path / "doc.jsonl"
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_response()) as mock_open:
+        pipeline_mod._qvac_ingest(jsonl, "WS1")
+    body = json.loads(mock_open.call_args[0][0].data)
+    assert body["jsonlPath"] == str(jsonl)
+
+
+@pytest.mark.unit
+def test_qvac_ingest_rebuild_defaults_to_false(tmp_path):
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_response()) as mock_open:
+        pipeline_mod._qvac_ingest(tmp_path / "doc.jsonl", "WS1")
+    body = json.loads(mock_open.call_args[0][0].data)
+    assert body["rebuild"] is False
+
+
+@pytest.mark.unit
+def test_qvac_ingest_rebuild_true_when_passed(tmp_path):
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_response()) as mock_open:
+        pipeline_mod._qvac_ingest(tmp_path / "doc.jsonl", "WS1", rebuild=True)
+    body = json.loads(mock_open.call_args[0][0].data)
+    assert body["rebuild"] is True
+
+
+@pytest.mark.unit
+def test_qvac_ingest_content_type_is_json(tmp_path):
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_response()) as mock_open:
+        pipeline_mod._qvac_ingest(tmp_path / "doc.jsonl", "WS1")
+    req = mock_open.call_args[0][0]
+    assert req.get_header("Content-type") == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# _qvac_ingest — resilience (service not running must not break the pipeline)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_qvac_ingest_does_not_raise_on_connection_refused(tmp_path):
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("connection refused")):
+        pipeline_mod._qvac_ingest(tmp_path / "doc.jsonl", "WS1")  # must not raise
+
+
+@pytest.mark.unit
+def test_qvac_ingest_does_not_raise_on_timeout(tmp_path):
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("timed out")):
+        pipeline_mod._qvac_ingest(tmp_path / "doc.jsonl", "WS1")
+
+
+@pytest.mark.unit
+def test_qvac_ingest_does_not_raise_on_generic_exception(tmp_path):
+    with patch("urllib.request.urlopen", side_effect=Exception("unexpected error")):
+        pipeline_mod._qvac_ingest(tmp_path / "doc.jsonl", "WS1")

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -47,7 +47,15 @@ print_error() {
 print_section "Checking Prerequisites"
 
 if ! command -v node &> /dev/null; then
-    print_error "Node.js is not installed. Please install Node.js 18+"
+    print_error "Node.js is not installed. Please install Node.js 22.17 or later."
+    exit 1
+fi
+
+# @qvac/sdk uses bare runtime shims that require Node.js >= 22.17
+NODE_MAJOR=$(node --version | sed 's/v//' | cut -d. -f1)
+NODE_MINOR=$(node --version | sed 's/v//' | cut -d. -f2)
+if [ "$NODE_MAJOR" -lt 22 ] || { [ "$NODE_MAJOR" -eq 22 ] && [ "$NODE_MINOR" -lt 17 ]; }; then
+    print_error "Node.js 22.17+ is required (found $(node --version)). The @qvac/sdk package will not load on older versions."
     exit 1
 fi
 
@@ -111,6 +119,18 @@ fi
 
 echo "✅ Backend setup complete"
 
+# Setup QVAC service
+print_section "Setting up QVAC Service"
+
+cd "$PROJECT_DIR/workers/qvac-service"
+
+if [ ! -d "node_modules" ]; then
+    echo "Installing QVAC service dependencies..."
+    npm install --silent
+fi
+
+echo "QVAC service setup complete"
+
 # Setup Frontend
 print_section "Setting up Frontend"
 
@@ -136,10 +156,18 @@ print_section "Starting Development Servers"
 echo ""
 echo "Backend will start on:   http://localhost:8000"
 echo "API Documentation:       http://localhost:8000/docs"
+echo "QVAC service on:         http://localhost:3001"
 echo "Frontend will start on:  http://localhost:3000"
 echo ""
-print_warning "Keep this terminal open to run both servers"
+print_warning "Keep this terminal open to run all servers"
 echo ""
+
+# Start QVAC service in background
+echo "Starting QVAC service..."
+cd "$PROJECT_DIR/workers/qvac-service"
+node src/server.js > "$PROJECT_DIR/workers/qvac-service/qvac.log" 2>&1 &
+QVAC_PID=$!
+echo "QVAC service PID: $QVAC_PID"
 
 # Start backend in background
 echo "Starting FastAPI backend..."
@@ -148,6 +176,9 @@ source venv/bin/activate 2>/dev/null || source venv/Scripts/activate 2>/dev/null
 python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 > backend.log 2>&1 &
 BACKEND_PID=$!
 echo "Backend PID: $BACKEND_PID"
+
+# Register cleanup before any blocking call
+trap "kill $BACKEND_PID $QVAC_PID 2>/dev/null" EXIT
 
 # Wait a bit for backend to start
 sleep 3
@@ -161,13 +192,10 @@ echo "  Admin:   admin@bitpolito.it / DevAdmin@2024!Secure"
 echo "  Student: student@bitpolito.it / DevStudent@2024!Learn"
 echo ""
 
-# Start frontend
+# Start frontend (blocks until Ctrl-C)
 echo "Starting Next.js frontend..."
 cd "$PROJECT_DIR/apps/web"
 npm run dev
-
-# Cleanup on exit
-trap "kill $BACKEND_PID 2>/dev/null" EXIT
 
 echo ""
 print_section "Development Servers Stopped"

--- a/workers/qvac-service/Dockerfile
+++ b/workers/qvac-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+CMD ["node", "src/server.js"]

--- a/workers/qvac-service/package.json
+++ b/workers/qvac-service/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "qvac-service",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "ingest": "node src/ingest.js",
+    "test": "node --test --experimental-test-module-mocks tests/*.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@qvac/sdk": "^0.9.1"
+  }
+}

--- a/workers/qvac-service/src/ingest.js
+++ b/workers/qvac-service/src/ingest.js
@@ -1,0 +1,51 @@
+import { readFileSync } from "fs";
+import { ragIngest, ragDeleteWorkspace } from "@qvac/sdk";
+import { getEmbeddingModelId } from "./models.js";
+
+/**
+ * Reads a JSONL file from the Python ingestion pipeline and indexes
+ * paragraph-level chunks into a QVAC HyperDB workspace.
+ *
+ * Only PARAGRAPH chunks are indexed — SECTION and MICRO chunks exist for
+ * context expansion in the Python side but are not retrieval units here.
+ * This matches the behavior of the old VerilocalEmbedder with ChromaDB.
+ *
+ * @param {string}  jsonlPath  absolute path to the *_contingency.jsonl file
+ * @param {string}  workspace  workspace name; use course_id for per-course isolation
+ * @param {boolean} rebuild    drop the existing workspace before ingesting
+ */
+export async function ingestFromJsonl(jsonlPath, workspace, rebuild = false) {
+  const modelId = getEmbeddingModelId();
+  if (!modelId) throw new Error("Embedding model not loaded — call initModels() first.");
+
+  const lines = readFileSync(jsonlPath, "utf-8")
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+
+  const paragraphChunks = lines.filter((c) => c.chunk_type === "paragraph");
+
+  if (paragraphChunks.length === 0) {
+    console.warn("[ingest] no paragraph chunks found in", jsonlPath);
+    return;
+  }
+
+  if (rebuild) {
+    // Silently ignore errors — workspace may not exist on first run.
+    await ragDeleteWorkspace({ workspace }).catch(() => {});
+    console.log(`[ingest] workspace '${workspace}' dropped`);
+  }
+
+  console.log(`[ingest] indexing ${paragraphChunks.length} chunks into '${workspace}'...`);
+
+  // chunk: false — the Python pipeline already split the text; don't re-chunk.
+  const result = await ragIngest({
+    modelId,
+    workspace,
+    documents: paragraphChunks.map((c) => c.text),
+    chunk: false,
+  });
+
+  console.log(`[ingest] done. processed: ${result.processed.length}`);
+  return result;
+}

--- a/workers/qvac-service/src/ingest.js
+++ b/workers/qvac-service/src/ingest.js
@@ -1,6 +1,27 @@
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import path from "path";
 import { ragIngest, ragDeleteWorkspace } from "@qvac/sdk";
 import { getEmbeddingModelId } from "./models.js";
+
+const INGEST_DIR = process.env.QVAC_INGEST_DIR ?? "/qvac_ingest";
+
+function metaPath(workspace) {
+  return path.join(INGEST_DIR, `${workspace}_meta.json`);
+}
+
+function loadMeta(workspace) {
+  const p = metaPath(workspace);
+  if (!existsSync(p)) return {};
+  try {
+    return JSON.parse(readFileSync(p, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+function saveMeta(workspace, meta) {
+  writeFileSync(metaPath(workspace), JSON.stringify(meta), "utf-8");
+}
 
 /**
  * Reads a JSONL file from the Python ingestion pipeline and indexes
@@ -9,6 +30,10 @@ import { getEmbeddingModelId } from "./models.js";
  * Only PARAGRAPH chunks are indexed — SECTION and MICRO chunks exist for
  * context expansion in the Python side but are not retrieval units here.
  * This matches the behavior of the old VerilocalEmbedder with ChromaDB.
+ *
+ * A sidecar `{workspace}_meta.json` file in QVAC_INGEST_DIR stores the
+ * mapping from QVAC-assigned IDs to citation metadata (page, slide, section,
+ * label, doc_id) so that query results can carry full citation information.
  *
  * @param {string}  jsonlPath  absolute path to the *_contingency.jsonl file
  * @param {string}  workspace  workspace name; use course_id for per-course isolation
@@ -31,20 +56,38 @@ export async function ingestFromJsonl(jsonlPath, workspace, rebuild = false) {
   }
 
   if (rebuild) {
-    // Silently ignore errors — workspace may not exist on first run.
     await ragDeleteWorkspace({ workspace }).catch(() => {});
     console.log(`[ingest] workspace '${workspace}' dropped`);
+    saveMeta(workspace, {});
   }
 
   console.log(`[ingest] indexing ${paragraphChunks.length} chunks into '${workspace}'...`);
 
-  // chunk: false — the Python pipeline already split the text; don't re-chunk.
   const result = await ragIngest({
     modelId,
     workspace,
     documents: paragraphChunks.map((c) => c.text),
     chunk: false,
   });
+
+  // Build id → citation metadata mapping, accounting for dropped indices.
+  const keptChunks = paragraphChunks.filter(
+    (_, i) => !result.droppedIndices.includes(i)
+  );
+  const existingMeta = loadMeta(workspace);
+  result.processed.forEach((p, j) => {
+    if (p.status === "fulfilled" && p.id && keptChunks[j]) {
+      const c = keptChunks[j];
+      existingMeta[p.id] = {
+        label: c.citation_label ?? "",
+        page: c.citation_page ?? 0,
+        slide: c.citation_slide ?? 0,
+        section: c.citation_section ?? "",
+        doc_id: c.doc_id ?? "",
+      };
+    }
+  });
+  saveMeta(workspace, existingMeta);
 
   console.log(`[ingest] done. processed: ${result.processed.length}`);
   return result;

--- a/workers/qvac-service/src/models.js
+++ b/workers/qvac-service/src/models.js
@@ -1,0 +1,41 @@
+import {
+  loadModel,
+  unloadModel,
+  startQVACProvider,
+  stopQVACProvider,
+  close,
+  GTE_LARGE_FP16,
+} from "@qvac/sdk";
+
+// Override embedding model via env var; falls back to GTE_LARGE_FP16 (~670 MB).
+const EMB_SRC = process.env.QVAC_EMB_SRC ?? GTE_LARGE_FP16;
+
+let embeddingModelId = null;
+
+// LLM generation is not configured yet.
+// query.js returns raw retrieved context until a model is wired in here.
+// To add one: loadModel({ modelSrc: QWEN3_4B_INST_Q4_K_M, modelType: "llm" })
+// and export getLlmModelId() returning its id.
+
+export async function initModels() {
+  await startQVACProvider();
+
+  console.log("[qvac] loading embedding model...");
+  embeddingModelId = await loadModel({
+    modelSrc: EMB_SRC,
+    modelType: "embeddings",
+    onProgress: (p) => process.stdout.write(`\r  ${p.percentage.toFixed(0)}%`),
+  });
+  console.log("\n[qvac] embedding model ready:", embeddingModelId);
+}
+
+export async function shutdownModels() {
+  if (embeddingModelId) await unloadModel({ modelId: embeddingModelId });
+  await stopQVACProvider();
+  await close();
+}
+
+export function getEmbeddingModelId() { return embeddingModelId; }
+
+// Returns null until an LLM is configured above.
+export function getLlmModelId() { return null; }

--- a/workers/qvac-service/src/query.js
+++ b/workers/qvac-service/src/query.js
@@ -1,11 +1,25 @@
+import { readFileSync, existsSync } from "fs";
+import path from "path";
 import { ragSearch } from "@qvac/sdk";
 import { getEmbeddingModelId, getLlmModelId } from "./models.js";
+
+const INGEST_DIR = process.env.QVAC_INGEST_DIR ?? "/qvac_ingest";
 
 // Returned when the LLM is not configured.
 // FastAPI chat_service.py treats this as a valid answer string.
 const LLM_PLACEHOLDER_NOTE =
   "[LLM not configured] Retrieved context shown below. " +
   "Wire up a generation model in src/models.js to get synthesized answers.";
+
+function loadMeta(workspace) {
+  const p = path.join(INGEST_DIR, `${workspace}_meta.json`);
+  if (!existsSync(p)) return {};
+  try {
+    return JSON.parse(readFileSync(p, "utf-8"));
+  } catch {
+    return {};
+  }
+}
 
 /**
  * RAG query: semantic search over the workspace, then optionally generate
@@ -18,7 +32,7 @@ const LLM_PLACEHOLDER_NOTE =
  * @param {string} question   student's question
  * @param {string} workspace  QVAC workspace name (course_id)
  * @param {number} topK       chunks to retrieve
- * @returns {{ answer: string, sources: { score: number, snippet: string }[] }}
+ * @returns {{ answer: string, sources: { score, snippet, label, page, slide, section, doc_id }[] }}
  */
 export async function queryRag(question, workspace, topK = 5) {
   const embModelId = getEmbeddingModelId();
@@ -38,15 +52,23 @@ export async function queryRag(question, workspace, topK = 5) {
     };
   }
 
-  const sources = results.map((r) => ({
-    score: r.score,
-    snippet: r.content.slice(0, 200),
-  }));
+  const meta = loadMeta(workspace);
+  const sources = results.map((r) => {
+    const m = meta[r.id] ?? {};
+    return {
+      score: r.score,
+      snippet: r.content.slice(0, 200),
+      label: m.label ?? "",
+      page: m.page ?? 0,
+      slide: m.slide ?? 0,
+      section: m.section ?? "",
+      doc_id: m.doc_id ?? "",
+    };
+  });
 
   const llmId = getLlmModelId();
 
   if (!llmId) {
-    // No LLM yet — return the raw chunks so the rest of the pipeline works.
     const rawContext = results
       .map((r, i) => `[${i + 1}] ${r.content}`)
       .join("\n\n---\n\n");
@@ -57,8 +79,6 @@ export async function queryRag(question, workspace, topK = 5) {
     };
   }
 
-  // --- Generation (active when getLlmModelId() returns a model id) ---
-  // Import completion lazily so the file loads cleanly without an LLM.
   const { completion } = await import("@qvac/sdk");
 
   const history = [

--- a/workers/qvac-service/src/query.js
+++ b/workers/qvac-service/src/query.js
@@ -1,0 +1,89 @@
+import { ragSearch } from "@qvac/sdk";
+import { getEmbeddingModelId, getLlmModelId } from "./models.js";
+
+// Returned when the LLM is not configured.
+// FastAPI chat_service.py treats this as a valid answer string.
+const LLM_PLACEHOLDER_NOTE =
+  "[LLM not configured] Retrieved context shown below. " +
+  "Wire up a generation model in src/models.js to get synthesized answers.";
+
+/**
+ * RAG query: semantic search over the workspace, then optionally generate
+ * an answer with the LLM.  When no LLM is configured, returns the raw
+ * retrieved chunks instead so the pipeline is still usable end-to-end.
+ *
+ * topK default of 5 keeps total context well within the 4096-token limit
+ * of small quantized models (1500-char chunks × 5 ≈ 1500 tokens).
+ *
+ * @param {string} question   student's question
+ * @param {string} workspace  QVAC workspace name (course_id)
+ * @param {number} topK       chunks to retrieve
+ * @returns {{ answer: string, sources: { score: number, snippet: string }[] }}
+ */
+export async function queryRag(question, workspace, topK = 5) {
+  const embModelId = getEmbeddingModelId();
+  if (!embModelId) throw new Error("Embedding model not loaded — call initModels() first.");
+
+  const results = await ragSearch({
+    modelId: embModelId,
+    workspace,
+    query: question,
+    topK,
+  });
+
+  if (results.length === 0) {
+    return {
+      answer: "No relevant content found for this question in the indexed course material.",
+      sources: [],
+    };
+  }
+
+  const sources = results.map((r) => ({
+    score: r.score,
+    snippet: r.content.slice(0, 200),
+  }));
+
+  const llmId = getLlmModelId();
+
+  if (!llmId) {
+    // No LLM yet — return the raw chunks so the rest of the pipeline works.
+    const rawContext = results
+      .map((r, i) => `[${i + 1}] ${r.content}`)
+      .join("\n\n---\n\n");
+
+    return {
+      answer: `${LLM_PLACEHOLDER_NOTE}\n\n${rawContext}`,
+      sources,
+    };
+  }
+
+  // --- Generation (active when getLlmModelId() returns a model id) ---
+  // Import completion lazily so the file loads cleanly without an LLM.
+  const { completion } = await import("@qvac/sdk");
+
+  const history = [
+    {
+      role: "system",
+      content:
+        "You are a Bitcoin education assistant for BitPolito Academy. " +
+        "Answer the student's question using ONLY the context provided. " +
+        "Be concise and precise. Cite the source label (e.g. 'p. 7', 'Slide 5') " +
+        "when referencing specific content. " +
+        "If the answer is not in the context, say so explicitly.",
+    },
+    {
+      role: "user",
+      content:
+        `Context:\n${results.map((r, i) => `[${i + 1}] ${r.content}`).join("\n\n---\n\n")}` +
+        `\n\nQuestion: ${question}`,
+    },
+  ];
+
+  let answer = "";
+  const result = completion({ modelId: llmId, history, stream: false });
+  for await (const token of result.tokenStream) {
+    answer += token;
+  }
+
+  return { answer, sources };
+}

--- a/workers/qvac-service/src/server.js
+++ b/workers/qvac-service/src/server.js
@@ -1,0 +1,67 @@
+import { createServer } from "http";
+import { initModels, shutdownModels } from "./models.js";
+import { ingestFromJsonl } from "./ingest.js";
+import { queryRag } from "./query.js";
+
+const PORT = parseInt(process.env.QVAC_PORT ?? "3001", 10);
+
+// Reads the full request body and parses it as JSON.
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk) => (data += chunk));
+    req.on("end", () => {
+      try { resolve(JSON.parse(data)); }
+      catch (e) { reject(new Error("Invalid JSON in request body")); }
+    });
+    req.on("error", reject);
+  });
+}
+
+function send(res, status, body) {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    // POST /ingest  { jsonlPath: string, workspace: string, rebuild?: boolean }
+    // Called by FastAPI after the Python ingestion pipeline writes a JSONL file.
+    if (req.method === "POST" && req.url === "/ingest") {
+      const { jsonlPath, workspace, rebuild = false } = await readBody(req);
+      await ingestFromJsonl(jsonlPath, workspace, rebuild);
+      return send(res, 200, { ok: true });
+    }
+
+    // POST /query  { question: string, workspace: string, topK?: number }
+    // Returns { answer: string, sources: [{ score, snippet }] }.
+    if (req.method === "POST" && req.url === "/query") {
+      const { question, workspace, topK = 5 } = await readBody(req);
+      const result = await queryRag(question, workspace, topK);
+      return send(res, 200, result);
+    }
+
+    // GET /health — used by FastAPI to detect whether the service is up.
+    if (req.method === "GET" && req.url === "/health") {
+      return send(res, 200, { status: "ok" });
+    }
+
+    send(res, 404, { error: "not found" });
+  } catch (err) {
+    console.error("[server] error:", err.message);
+    send(res, 500, { error: err.message });
+  }
+});
+
+// Give in-flight requests a chance to finish before killing models.
+process.on("SIGTERM", async () => {
+  console.log("[server] shutting down...");
+  await shutdownModels();
+  server.close(() => process.exit(0));
+});
+
+await initModels();
+
+server.listen(PORT, () => {
+  console.log(`[qvac-service] listening on http://localhost:${PORT}`);
+});

--- a/workers/qvac-service/tests/ingest.test.js
+++ b/workers/qvac-service/tests/ingest.test.js
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for src/ingest.js.
+ *
+ * @qvac/sdk and src/models.js are fully mocked — no model download happens.
+ * Tests run against JSONL data written to a temp directory.
+ */
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// SDK mock — registered before ingest.js is imported
+// ---------------------------------------------------------------------------
+
+const mockRagIngest = mock.fn(async () => ({ processed: ["id1", "id2"] }));
+const mockRagDeleteWorkspace = mock.fn(async () => {});
+
+await mock.module("@qvac/sdk", {
+  namedExports: {
+    ragIngest: mockRagIngest,
+    ragDeleteWorkspace: mockRagDeleteWorkspace,
+    ragSearch: mock.fn(),
+    completion: mock.fn(),
+    loadModel: mock.fn(),
+    unloadModel: mock.fn(),
+    startQVACProvider: mock.fn(),
+    stopQVACProvider: mock.fn(),
+    close: mock.fn(),
+    GTE_LARGE_FP16: {},
+    QWEN3_4B_INST_Q4_K_M: {},
+  },
+});
+
+// models.js mock — use mock.fn() so individual tests can override the return value
+const mockGetEmbeddingModelId = mock.fn(() => "test-emb-id");
+
+await mock.module(import.meta.resolve("../src/models.js"), {
+  namedExports: {
+    getEmbeddingModelId: mockGetEmbeddingModelId,
+    getLlmModelId: () => null,
+    initModels: mock.fn(),
+    shutdownModels: mock.fn(),
+  },
+});
+
+const { ingestFromJsonl } = await import("../src/ingest.js");
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const TMP = join(tmpdir(), `qvac-ingest-test-${Date.now()}`);
+mkdirSync(TMP, { recursive: true });
+
+function writeJsonl(name, chunks) {
+  const path = join(TMP, name);
+  writeFileSync(path, chunks.map((c) => JSON.stringify(c)).join("\n"));
+  return path;
+}
+
+const PARA  = { chunk_type: "paragraph", text: "Bitcoin uses UTXO." };
+const PARA2 = { chunk_type: "paragraph", text: "Proof-of-work secures the chain." };
+const SEC   = { chunk_type: "section",   text: "1. Transactions" };
+const MICRO = { chunk_type: "micro",     text: "UTXO." };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ingestFromJsonl", () => {
+  beforeEach(() => {
+    mockRagIngest.mock.resetCalls();
+    mockRagDeleteWorkspace.mock.resetCalls();
+    mockGetEmbeddingModelId.mock.resetCalls();
+    // Restore default implementation after any per-test override
+    mockGetEmbeddingModelId.mock.restore?.();
+  });
+
+  // --- happy path ---
+
+  it("calls ragIngest with chunk: false (no re-chunking)", async () => {
+    const path = writeJsonl("basic.jsonl", [PARA]);
+    await ingestFromJsonl(path, "WS1");
+    assert.equal(mockRagIngest.mock.calls.length, 1);
+    assert.equal(mockRagIngest.mock.calls[0].arguments[0].chunk, false);
+  });
+
+  it("passes the workspace to ragIngest", async () => {
+    const path = writeJsonl("ws.jsonl", [PARA]);
+    await ingestFromJsonl(path, "BTC_2025");
+    assert.equal(mockRagIngest.mock.calls[0].arguments[0].workspace, "BTC_2025");
+  });
+
+  it("passes the embedding model id to ragIngest", async () => {
+    const path = writeJsonl("model.jsonl", [PARA]);
+    await ingestFromJsonl(path, "WS1");
+    assert.equal(mockRagIngest.mock.calls[0].arguments[0].modelId, "test-emb-id");
+  });
+
+  it("returns the ragIngest result", async () => {
+    const path = writeJsonl("result.jsonl", [PARA]);
+    const result = await ingestFromJsonl(path, "WS1");
+    assert.deepEqual(result.processed, ["id1", "id2"]);
+  });
+
+  // --- filtering ---
+
+  it("indexes only paragraph chunks — discards section and micro", async () => {
+    const path = writeJsonl("mixed.jsonl", [PARA, SEC, MICRO]);
+    await ingestFromJsonl(path, "WS1");
+    const docs = mockRagIngest.mock.calls[0].arguments[0].documents;
+    assert.deepEqual(docs, [PARA.text]);
+  });
+
+  it("indexes all paragraph chunks when multiple are present", async () => {
+    const path = writeJsonl("multi.jsonl", [PARA, SEC, PARA2, MICRO]);
+    await ingestFromJsonl(path, "WS1");
+    const docs = mockRagIngest.mock.calls[0].arguments[0].documents;
+    assert.deepEqual(docs, [PARA.text, PARA2.text]);
+  });
+
+  it("skips ragIngest entirely when no paragraph chunks are found", async () => {
+    const path = writeJsonl("no-para.jsonl", [SEC, MICRO]);
+    await ingestFromJsonl(path, "WS1");
+    assert.equal(mockRagIngest.mock.calls.length, 0);
+  });
+
+  // --- rebuild flag ---
+
+  it("calls ragDeleteWorkspace before ingesting when rebuild=true", async () => {
+    const path = writeJsonl("rebuild.jsonl", [PARA]);
+    await ingestFromJsonl(path, "WS1", true);
+    assert.equal(mockRagDeleteWorkspace.mock.calls.length, 1);
+    assert.equal(mockRagDeleteWorkspace.mock.calls[0].arguments[0].workspace, "WS1");
+  });
+
+  it("calls ragDeleteWorkspace before ragIngest (order matters)", async () => {
+    const callOrder = [];
+    mockRagDeleteWorkspace.mock.mockImplementationOnce(async () => {
+      callOrder.push("delete");
+    });
+    mockRagIngest.mock.mockImplementationOnce(async () => {
+      callOrder.push("ingest");
+      return { processed: [] };
+    });
+
+    const path = writeJsonl("order.jsonl", [PARA]);
+    await ingestFromJsonl(path, "WS1", true);
+    assert.deepEqual(callOrder, ["delete", "ingest"]);
+  });
+
+  it("does not call ragDeleteWorkspace when rebuild=false", async () => {
+    const path = writeJsonl("no-rebuild.jsonl", [PARA]);
+    await ingestFromJsonl(path, "WS1", false);
+    assert.equal(mockRagDeleteWorkspace.mock.calls.length, 0);
+  });
+
+  it("does not call ragDeleteWorkspace by default (rebuild defaults to false)", async () => {
+    const path = writeJsonl("default-rebuild.jsonl", [PARA]);
+    await ingestFromJsonl(path, "WS1");
+    assert.equal(mockRagDeleteWorkspace.mock.calls.length, 0);
+  });
+
+  // --- guard: model not loaded ---
+
+  it("throws when embedding model is not loaded", async () => {
+    // Override just for this call
+    mockGetEmbeddingModelId.mock.mockImplementationOnce(() => null);
+    const path = writeJsonl("no-model.jsonl", [PARA]);
+    await assert.rejects(
+      () => ingestFromJsonl(path, "WS1"),
+      (err) => {
+        assert.ok(err.message.includes("Embedding model not loaded"));
+        return true;
+      }
+    );
+  });
+});

--- a/workers/qvac-service/tests/query.test.js
+++ b/workers/qvac-service/tests/query.test.js
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for src/query.js.
+ *
+ * No LLM is configured (getLlmModelId returns null), so all tests
+ * exercise the placeholder path: ragSearch → raw context returned.
+ *
+ * @qvac/sdk and src/models.js are fully mocked.
+ */
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+// ---------------------------------------------------------------------------
+// SDK mock
+// ---------------------------------------------------------------------------
+
+const FAKE_RESULTS = [
+  { content: "Bitcoin is a peer-to-peer electronic cash system.", score: 0.92 },
+  { content: "Transactions are validated via proof-of-work.",    score: 0.85 },
+];
+
+const mockRagSearch = mock.fn(async () => FAKE_RESULTS);
+
+await mock.module("@qvac/sdk", {
+  namedExports: {
+    ragSearch: mockRagSearch,
+    ragIngest: mock.fn(),
+    ragDeleteWorkspace: mock.fn(),
+    completion: mock.fn(),
+    loadModel: mock.fn(),
+    unloadModel: mock.fn(),
+    startQVACProvider: mock.fn(),
+    stopQVACProvider: mock.fn(),
+    close: mock.fn(),
+    GTE_LARGE_FP16: {},
+    QWEN3_4B_INST_Q4_K_M: {},
+  },
+});
+
+// models.js mock — getLlmModelId returns null (no LLM configured)
+const mockGetEmbeddingModelId = mock.fn(() => "test-emb-id");
+
+await mock.module(import.meta.resolve("../src/models.js"), {
+  namedExports: {
+    getEmbeddingModelId: mockGetEmbeddingModelId,
+    getLlmModelId: () => null,
+    initModels: mock.fn(),
+    shutdownModels: mock.fn(),
+  },
+});
+
+const { queryRag } = await import("../src/query.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("queryRag — placeholder path (no LLM configured)", () => {
+  beforeEach(() => {
+    mockRagSearch.mock.resetCalls();
+    mockGetEmbeddingModelId.mock.resetCalls();
+    mockRagSearch.mock.restore?.();
+    mockGetEmbeddingModelId.mock.restore?.();
+  });
+
+  // --- ragSearch call ---
+
+  it("calls ragSearch with the question and workspace", async () => {
+    await queryRag("What is a UTXO?", "BTC_2025");
+    assert.equal(mockRagSearch.mock.calls.length, 1);
+    const arg = mockRagSearch.mock.calls[0].arguments[0];
+    assert.equal(arg.query, "What is a UTXO?");
+    assert.equal(arg.workspace, "BTC_2025");
+  });
+
+  it("passes modelId to ragSearch", async () => {
+    await queryRag("Explain SegWit.", "WS1");
+    const arg = mockRagSearch.mock.calls[0].arguments[0];
+    assert.equal(arg.modelId, "test-emb-id");
+  });
+
+  it("passes topK to ragSearch", async () => {
+    await queryRag("Explain Merkle trees.", "WS1", 3);
+    assert.equal(mockRagSearch.mock.calls[0].arguments[0].topK, 3);
+  });
+
+  it("uses topK=5 by default", async () => {
+    await queryRag("What is Bitcoin?", "WS1");
+    assert.equal(mockRagSearch.mock.calls[0].arguments[0].topK, 5);
+  });
+
+  // --- placeholder answer when no LLM ---
+
+  it("answer contains the placeholder note", async () => {
+    const { answer } = await queryRag("What is Bitcoin?", "WS1");
+    assert.ok(
+      answer.includes("[LLM not configured]"),
+      `placeholder note missing; got: "${answer.slice(0, 120)}"`
+    );
+  });
+
+  it("answer includes all retrieved chunk texts", async () => {
+    const { answer } = await queryRag("What is Bitcoin?", "WS1");
+    for (const r of FAKE_RESULTS) {
+      assert.ok(answer.includes(r.content), `chunk text missing from answer: "${r.content}"`);
+    }
+  });
+
+  // --- sources ---
+
+  it("sources length matches ragSearch result count", async () => {
+    const { sources } = await queryRag("What is Bitcoin?", "WS1");
+    assert.equal(sources.length, FAKE_RESULTS.length);
+  });
+
+  it("each source has score and snippet fields", async () => {
+    const { sources } = await queryRag("What is Bitcoin?", "WS1");
+    for (const src of sources) {
+      assert.ok("score" in src, "source missing score");
+      assert.ok("snippet" in src, "source missing snippet");
+      assert.equal(typeof src.score, "number");
+      assert.equal(typeof src.snippet, "string");
+    }
+  });
+
+  it("snippet is at most 200 characters", async () => {
+    const { sources } = await queryRag("What is Bitcoin?", "WS1");
+    for (const src of sources) {
+      assert.ok(src.snippet.length <= 200, `snippet too long: ${src.snippet.length}`);
+    }
+  });
+
+  it("source scores match ragSearch scores in order", async () => {
+    const { sources } = await queryRag("What is Bitcoin?", "WS1");
+    assert.equal(sources[0].score, FAKE_RESULTS[0].score);
+    assert.equal(sources[1].score, FAKE_RESULTS[1].score);
+  });
+
+  // --- empty corpus ---
+
+  it("returns no-content message when ragSearch returns nothing", async () => {
+    mockRagSearch.mock.mockImplementationOnce(async () => []);
+    const { answer, sources } = await queryRag("Unknown topic.", "EMPTY_WS");
+    assert.ok(answer.toLowerCase().includes("no relevant content"));
+    assert.deepEqual(sources, []);
+  });
+
+  it("returns empty sources when ragSearch returns nothing", async () => {
+    mockRagSearch.mock.mockImplementationOnce(async () => []);
+    const { sources } = await queryRag("Unknown topic.", "EMPTY_WS");
+    assert.deepEqual(sources, []);
+  });
+
+  // --- guard: embedding model not loaded ---
+
+  it("throws when embedding model is not loaded", async () => {
+    mockGetEmbeddingModelId.mock.mockImplementationOnce(() => null);
+    await assert.rejects(
+      () => queryRag("What is Bitcoin?", "WS1"),
+      (err) => {
+        assert.ok(err.message.includes("Embedding model not loaded"));
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

* **QVAC Node.js service** (`workers/qvac-service/`): new microservice with four modules (`ingest`, `query`, `models`, `server`) exposing a REST endpoint for retrieval. Added to `docker-compose.yml` and the startup script.
* **Pipeline → QVAC wiring**: `pipeline.py` now invokes `ingest.js` after indexing on ChromaDB; `chat_service.py` and `chat_api.py` updated to perform retrieval via QVAC (with graceful fallback if the service is unreachable).
* **Docling tier-2 parser**: integrated as an automatic fallback in `module_2_parser.py` for complex layouts; includes a quality report generator.
* **Study UI**: `ContentChunks`, `LessonNav`, `ProgressBar`, `BadgeDisplay` added; `OutputPane` and `SourcePane` updated with lesson navigation, completion tracking, and citation rendering.
* **Complete test suite**: unit tests for chunker, parser, pipeline schema, and sys-modules aliasing; integration tests for chat, documents, quizzes/certificates, and end-to-end pipeline; frontend tests for `OutputPane`, `LessonNav`, `ProgressBar`, and study flow.

## Notes for the reviewer

This branch introduces a dependency on `workers/qvac-service` (Node.js).
For full local execution, run `npm install` in that directory or use `docker-compose up`.
Retrieval still works without the QVAC service running (fallback to an empty response in `chat_service`), but citations will not be returned.

`chat_service.py` is now coupled to QVAC; Phase 1 of the MVP plan will remove this layer by introducing a direct retrieval service on ChromaDB with a structured EvidencePack.

## Test plan

* [ ] `docker-compose up` → verify that the QVAC service starts on port 3001
* [ ] Upload PDF → poll status → `indexed`
* [ ] POST `/api/courses/{id}/chat` → response includes citations
* [ ] `pytest services/ai/tests/` → all tests pass
* [ ] `npm test` in `apps/web` → unit and integration tests pass
* [ ] CI pipeline is green
