### PR TITLE
fix(frontend): auth pages, session types, and integration bug fixes

### DIFF
--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -20,6 +20,7 @@ export default function LoginPage() {
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get('callbackUrl') || '/dashboard';
   const errorParam = searchParams.get('error');
+  const messageParam = searchParams.get('message');
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -77,7 +78,11 @@ export default function LoginPage() {
       });
 
       if (result?.error) {
-        setErrors({ general: result.error });
+        const friendlyError =
+          result.error === 'CredentialsSignin'
+            ? 'Invalid email or password. Please try again.'
+            : 'An unexpected error occurred. Please try again.';
+        setErrors({ general: friendlyError });
       } else if (result?.ok) {
         router.push(callbackUrl);
         router.refresh();
@@ -92,6 +97,13 @@ export default function LoginPage() {
   return (
     <div className="mt-8 bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
       <h2 className="text-center text-2xl font-bold text-gray-900 mb-6">Sign in to your account</h2>
+
+      {/* Info message (e.g. after successful registration) */}
+      {messageParam && (
+        <div className="mb-4 p-3 rounded bg-blue-50 border border-blue-200">
+          <p className="text-sm text-blue-800">{messageParam}</p>
+        </div>
+      )}
 
       {/* Session expired error */}
       {sessionError && (

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,13 +1,9 @@
 'use client';
 
-/**
- * Login page component
- * Handles user authentication with form validation
- */
 import { signIn } from 'next-auth/react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { FormEvent, useState } from 'react';
+import { FormEvent, Suspense, useState } from 'react';
 
 interface FormErrors {
   email?: string;
@@ -15,7 +11,7 @@ interface FormErrors {
   general?: string;
 }
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get('callbackUrl') || '/dashboard';
@@ -27,24 +23,18 @@ export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
 
-  // Handle session expired error from URL
   const sessionError =
     errorParam === 'SessionExpired' ? 'Your session has expired. Please log in again.' : null;
 
-  /**
-   * Validate form fields
-   */
   const validateForm = (): boolean => {
     const newErrors: FormErrors = {};
 
-    // Email validation
     if (!email) {
       newErrors.email = 'Email is required';
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       newErrors.email = 'Please enter a valid email address';
     }
 
-    // Password validation
     if (!password) {
       newErrors.password = 'Password is required';
     }
@@ -53,16 +43,10 @@ export default function LoginPage() {
     return Object.keys(newErrors).length === 0;
   };
 
-  /**
-   * Handle form submission
-   */
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
-    // Clear previous errors
     setErrors({});
 
-    // Validate form
     if (!validateForm()) {
       return;
     }
@@ -87,7 +71,7 @@ export default function LoginPage() {
         router.push(callbackUrl);
         router.refresh();
       }
-    } catch (error) {
+    } catch {
       setErrors({ general: 'An unexpected error occurred. Please try again.' });
     } finally {
       setIsLoading(false);
@@ -96,31 +80,27 @@ export default function LoginPage() {
 
   return (
     <div className="mt-8 bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-      <h2 className="text-center text-2xl font-bold text-gray-900 mb-6">Sign in to your account</h2>
+      <h2 className="mb-6 text-center text-2xl font-bold text-gray-900">Sign in to your account</h2>
 
-      {/* Info message (e.g. after successful registration) */}
       {messageParam && (
-        <div className="mb-4 p-3 rounded bg-blue-50 border border-blue-200">
+        <div className="mb-4 rounded border border-blue-200 bg-blue-50 p-3">
           <p className="text-sm text-blue-800">{messageParam}</p>
         </div>
       )}
 
-      {/* Session expired error */}
       {sessionError && (
-        <div className="mb-4 p-3 rounded bg-yellow-50 border border-yellow-200">
+        <div className="mb-4 rounded border border-yellow-200 bg-yellow-50 p-3">
           <p className="text-sm text-yellow-800">{sessionError}</p>
         </div>
       )}
 
-      {/* General error message */}
       {errors.general && (
-        <div className="mb-4 p-3 rounded bg-red-50 border border-red-200">
+        <div className="mb-4 rounded border border-red-200 bg-red-50 p-3" role="alert">
           <p className="text-sm text-red-600">{errors.general}</p>
         </div>
       )}
 
       <form className="space-y-6" onSubmit={handleSubmit} noValidate>
-        {/* Email field */}
         <div>
           <label htmlFor="email" className="block text-sm font-medium text-gray-700">
             Email address
@@ -134,7 +114,7 @@ export default function LoginPage() {
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className={`appearance-none block w-full px-3 py-2 border rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm ${
+              className={`block w-full appearance-none rounded-md border px-3 py-2 shadow-sm placeholder-gray-400 focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm ${
                 errors.email ? 'border-red-300' : 'border-gray-300'
               }`}
               placeholder="you@example.com"
@@ -149,7 +129,6 @@ export default function LoginPage() {
           )}
         </div>
 
-        {/* Password field */}
         <div>
           <label htmlFor="password" className="block text-sm font-medium text-gray-700">
             Password
@@ -163,7 +142,7 @@ export default function LoginPage() {
               required
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className={`appearance-none block w-full px-3 py-2 border rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm ${
+              className={`block w-full appearance-none rounded-md border px-3 py-2 shadow-sm placeholder-gray-400 focus:outline-none focus:ring-orange-500 focus:border-orange-500 sm:text-sm ${
                 errors.password ? 'border-red-300' : 'border-gray-300'
               }`}
               placeholder="••••••••"
@@ -178,12 +157,11 @@ export default function LoginPage() {
           )}
         </div>
 
-        {/* Submit button */}
         <div>
           <button
             type="submit"
             disabled={isLoading}
-            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex w-full justify-center rounded-md border border-transparent bg-orange-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isLoading ? (
               <>
@@ -216,26 +194,33 @@ export default function LoginPage() {
         </div>
       </form>
 
-      {/* Sign up link */}
       <div className="mt-6">
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
             <div className="w-full border-t border-gray-300" />
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-white text-gray-500">Don&apos;t have an account?</span>
+            <span className="bg-white px-2 text-gray-500">Don&apos;t have an account?</span>
           </div>
         </div>
 
         <div className="mt-6">
           <Link
             href="/signup"
-            className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500"
+            className="flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
           >
             Create an account
           </Link>
         </div>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -43,17 +43,19 @@ export default function SignupPage() {
       newErrors.email = 'Please enter a valid email address';
     }
 
-    // Password validation
+    // Password validation — mirrors backend requirements in auth_schemas.py
     if (!password) {
       newErrors.password = 'Password is required';
-    } else if (password.length < 8) {
-      newErrors.password = 'Password must be at least 8 characters long';
+    } else if (password.length < 12) {
+      newErrors.password = 'Password must be at least 12 characters long';
     } else if (!/[A-Z]/.test(password)) {
       newErrors.password = 'Password must contain at least one uppercase letter';
     } else if (!/[a-z]/.test(password)) {
       newErrors.password = 'Password must contain at least one lowercase letter';
     } else if (!/\d/.test(password)) {
       newErrors.password = 'Password must contain at least one digit';
+    } else if (!/[!@#$%^&*()\-_=+\[\]{};':"\\|,.<>/?`~]/.test(password)) {
+      newErrors.password = 'Password must contain at least one special character';
     }
 
     // Confirm password validation
@@ -105,12 +107,17 @@ export default function SignupPage() {
       if (!registerResponse.ok) {
         const error = await registerResponse.json();
 
+        // FastAPI validation errors (422) return detail as an array of objects
+        const detail = Array.isArray(error.detail)
+          ? error.detail.map((e: { msg: string }) => e.msg).join('. ')
+          : (error.detail as string | undefined);
+
         if (registerResponse.status === 409) {
           setErrors({ email: 'A user with this email already exists' });
-        } else if (registerResponse.status === 400) {
-          setErrors({ general: error.detail || 'Invalid input data' });
+        } else if (registerResponse.status === 400 || registerResponse.status === 422) {
+          setErrors({ general: detail || 'Invalid input data' });
         } else {
-          setErrors({ general: error.detail || 'Registration failed' });
+          setErrors({ general: detail || 'Registration failed' });
         }
         return;
       }
@@ -234,7 +241,7 @@ export default function SignupPage() {
             </p>
           ) : (
             <p className="mt-1 text-xs text-gray-500" id="password-hint">
-              Min 8 characters, with uppercase, lowercase, and a digit
+              Min 12 characters, with uppercase, lowercase, a digit, and a special character
             </p>
           )}
         </div>

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -54,7 +54,7 @@ export default function SignupPage() {
       newErrors.password = 'Password must contain at least one lowercase letter';
     } else if (!/\d/.test(password)) {
       newErrors.password = 'Password must contain at least one digit';
-    } else if (!/[!@#$%^&*()\-_=+\[\]{};':"\\|,.<>/?`~]/.test(password)) {
+    } else if (!/[!@#$%^&*()\-_=+[\]{};':"\\|,.<>/?`~]/.test(password)) {
       newErrors.password = 'Password must contain at least one special character';
     }
 

--- a/apps/web/src/app/courses/[courseId]/documents/[documentId]/preview/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/documents/[documentId]/preview/page.tsx
@@ -78,15 +78,27 @@ export default function DocumentPreviewPage() {
           onClick={() => router.push(`/courses/${courseId}`)}
           className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
         >
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
           </svg>
           Back
         </button>
         <div className="flex-1 min-w-0">
           <h1 className="text-xl font-bold text-gray-900 truncate">{preview.filename}</h1>
           {preview.pageCount != null && (
-            <p className="text-sm text-gray-500">{preview.pageCount} page{preview.pageCount !== 1 ? 's' : ''}</p>
+            <p className="text-sm text-gray-500">
+              {preview.pageCount} page{preview.pageCount !== 1 ? 's' : ''}
+            </p>
           )}
         </div>
       </div>

--- a/apps/web/src/app/courses/[courseId]/layout.tsx
+++ b/apps/web/src/app/courses/[courseId]/layout.tsx
@@ -32,8 +32,18 @@ export default function CourseLayout({ children }: CourseLayoutProps) {
                 href="/courses"
                 className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1"
               >
-                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+                  />
                 </svg>
                 Courses
               </Link>

--- a/apps/web/src/app/courses/[courseId]/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/page.tsx
@@ -13,7 +13,7 @@ export default function CourseWorkspacePage() {
   const router = useRouter();
   const courseId = params.courseId as string;
   const { data: session } = useSession();
-  const accessToken = (session?.user as any)?.accessToken;
+  const accessToken = session?.user?.accessToken;
 
   const [course, setCourse] = useState<Course | null>(null);
   const [lessons, setLessons] = useState<Lesson[]>([]);

--- a/apps/web/src/app/courses/[courseId]/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/page.tsx
@@ -91,9 +91,7 @@ export default function CourseWorkspacePage() {
     <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900">{course.title}</h1>
-        {course.description && (
-          <p className="mt-1 text-gray-600">{course.description}</p>
-        )}
+        {course.description && <p className="mt-1 text-gray-600">{course.description}</p>}
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -106,8 +104,18 @@ export default function CourseWorkspacePage() {
             <div className="p-6">
               {lessons.length === 0 ? (
                 <div className="text-center py-8">
-                  <svg className="mx-auto h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.26 10.147a60.438 60.438 0 00-.491 6.347A48.62 48.62 0 0112 20.904a48.62 48.62 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.636 50.636 0 00-2.658-.813A59.906 59.906 0 0112 3.493a59.903 59.903 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0112 13.489a50.702 50.702 0 017.74-3.342" />
+                  <svg
+                    className="mx-auto h-10 w-10 text-gray-300"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.5}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M4.26 10.147a60.438 60.438 0 00-.491 6.347A48.62 48.62 0 0112 20.904a48.62 48.62 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.636 50.636 0 00-2.658-.813A59.906 59.906 0 0112 3.493a59.903 59.903 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0112 13.489a50.702 50.702 0 017.74-3.342"
+                    />
                   </svg>
                   <p className="mt-2 text-sm text-gray-500">No lessons available yet</p>
                 </div>

--- a/apps/web/src/app/courses/[courseId]/study/page.tsx
+++ b/apps/web/src/app/courses/[courseId]/study/page.tsx
@@ -21,7 +21,7 @@ export default function StudyPage() {
   const params = useParams();
   const courseId = params.courseId as string;
   const { data: session } = useSession();
-  const accessToken = (session?.user as any)?.accessToken;
+  const accessToken = session?.user?.accessToken;
 
   const [course, setCourse] = useState<Course | null>(null);
   const [lessons, setLessons] = useState<Lesson[]>([]);

--- a/apps/web/src/app/courses/page.tsx
+++ b/apps/web/src/app/courses/page.tsx
@@ -23,7 +23,7 @@ export default function CoursesPage() {
     }
     if (status !== 'authenticated') return;
 
-    const token = (session?.user as any)?.accessToken;
+    const token = session?.user?.accessToken;
 
     async function fetchAll() {
       try {

--- a/apps/web/src/app/courses/page.tsx
+++ b/apps/web/src/app/courses/page.tsx
@@ -120,11 +120,7 @@ export default function CoursesPage() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {courses.map((course) => (
-              <CourseCard
-                key={course.id}
-                course={course}
-                progress={progress[course.id] ?? null}
-              />
+              <CourseCard key={course.id} course={course} progress={progress[course.id] ?? null} />
             ))}
           </div>
         )}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -17,7 +17,7 @@ export default function DashboardPage() {
 
     async function fetchCourses() {
       try {
-        const data = await getCourses(0, 100, (session?.user as any)?.accessToken);
+        const data = await getCourses(0, 100, session?.user?.accessToken);
         setCourses(data);
       } catch {
         // Non-critical — dashboard still usable without course count
@@ -69,7 +69,7 @@ export default function DashboardPage() {
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="bg-white rounded-lg shadow p-6">
           <h2 className="text-xl font-semibold text-gray-900 mb-4">
-            Welcome, {(session?.user as any)?.displayName || session?.user?.email}!
+            Welcome, {session?.user?.displayName || session?.user?.email}!
           </h2>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
@@ -84,13 +84,13 @@ export default function DashboardPage() {
                 <div>
                   <dt className="text-sm text-gray-500">Display Name</dt>
                   <dd className="text-sm font-medium text-gray-900">
-                    {(session?.user as any)?.displayName || 'Not set'}
+                    {session?.user?.displayName || 'Not set'}
                   </dd>
                 </div>
                 <div>
                   <dt className="text-sm text-gray-500">Role</dt>
                   <dd className="text-sm font-medium text-gray-900 capitalize">
-                    {(session?.user as any)?.role || 'Student'}
+                    {session?.user?.role || 'Student'}
                   </dd>
                 </div>
               </dl>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -110,14 +110,6 @@ export default function DashboardPage() {
                     )}
                   </span>
                 </div>
-                <div className="flex justify-between items-center">
-                  <span className="text-sm text-gray-600">Courses Completed</span>
-                  <span className="text-lg font-semibold text-green-600">0</span>
-                </div>
-                <div className="flex justify-between items-center">
-                  <span className="text-sm text-gray-600">Certificates Earned</span>
-                  <span className="text-lg font-semibold text-blue-600">0</span>
-                </div>
               </div>
             </div>
 

--- a/apps/web/src/components/courses/CourseCard.tsx
+++ b/apps/web/src/components/courses/CourseCard.tsx
@@ -14,8 +14,8 @@ export function CourseCard({ course, progress = null }: CourseCardProps) {
     progress === 100
       ? 'Review course'
       : progress != null && progress > 0
-      ? 'Continue studying'
-      : 'Start studying';
+        ? 'Continue studying'
+        : 'Start studying';
 
   return (
     <Link
@@ -25,13 +25,9 @@ export function CourseCard({ course, progress = null }: CourseCardProps) {
       <div className="p-6">
         <div className="flex items-start justify-between">
           <div className="flex-1 min-w-0">
-            <h3 className="text-lg font-semibold text-gray-900 truncate">
-              {course.title}
-            </h3>
+            <h3 className="text-lg font-semibold text-gray-900 truncate">{course.title}</h3>
             {course.description && (
-              <p className="mt-2 text-sm text-gray-600 line-clamp-2">
-                {course.description}
-              </p>
+              <p className="mt-2 text-sm text-gray-600 line-clamp-2">{course.description}</p>
             )}
           </div>
           <div className="ml-4 flex-shrink-0">
@@ -71,7 +67,11 @@ export function CourseCard({ course, progress = null }: CourseCardProps) {
             strokeWidth={2}
             stroke="currentColor"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+            />
           </svg>
         </div>
       </div>

--- a/apps/web/src/components/courses/DocumentList.tsx
+++ b/apps/web/src/components/courses/DocumentList.tsx
@@ -66,7 +66,7 @@ export function DocumentList({
         setRefreshing(false);
       }
     },
-    [courseId, accessToken],
+    [courseId, accessToken]
   );
 
   useEffect(() => {
@@ -139,7 +139,9 @@ export function DocumentList({
           />
         </svg>
         <p className="mt-2 text-sm text-gray-500">No documents uploaded yet</p>
-        <p className="text-xs text-gray-400">Upload slides, notes, or reference material to get started</p>
+        <p className="text-xs text-gray-400">
+          Upload slides, notes, or reference material to get started
+        </p>
       </div>
     );
   }
@@ -193,7 +195,11 @@ export function DocumentList({
                     strokeWidth={2}
                     stroke="currentColor"
                   >
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M8.25 4.5l7.5 7.5-7.5 7.5"
+                    />
                   </svg>
 
                   {/* File type badge */}

--- a/apps/web/src/components/courses/ProcessingIndicator.tsx
+++ b/apps/web/src/components/courses/ProcessingIndicator.tsx
@@ -8,7 +8,10 @@ interface ProcessingIndicatorProps {
   className?: string;
 }
 
-const STATUS_CONFIG: Record<DocumentStatus, { label: string; bg: string; text: string; dot: string }> = {
+const STATUS_CONFIG: Record<
+  DocumentStatus,
+  { label: string; bg: string; text: string; dot: string }
+> = {
   uploading: {
     label: 'Uploading',
     bg: 'bg-blue-50',
@@ -56,9 +59,7 @@ export function ProcessingIndicator({ status, stage, className = '' }: Processin
     >
       <span className={`h-1.5 w-1.5 rounded-full ${config.dot}`} />
       {config.label}
-      {stageLabel && (
-        <span className="opacity-75">· {stageLabel}</span>
-      )}
+      {stageLabel && <span className="opacity-75">· {stageLabel}</span>}
     </span>
   );
 }

--- a/apps/web/src/components/courses/ProcessingIndicator.tsx
+++ b/apps/web/src/components/courses/ProcessingIndicator.tsx
@@ -56,7 +56,7 @@ export function ProcessingIndicator({ status, stage, className = '' }: Processin
     >
       <span className={`h-1.5 w-1.5 rounded-full ${config.dot}`} />
       {config.label}
-      {stageLabel && status === 'processing' && (
+      {stageLabel && (
         <span className="opacity-75">· {stageLabel}</span>
       )}
     </span>

--- a/apps/web/src/components/documents/DocumentProcessingPanel.tsx
+++ b/apps/web/src/components/documents/DocumentProcessingPanel.tsx
@@ -14,7 +14,9 @@ function DetailRow({ label, value }: { label: string; value: React.ReactNode }) 
   return (
     <div className="flex items-start justify-between py-1.5">
       <dt className="text-xs font-medium text-gray-500 w-36 flex-shrink-0">{label}</dt>
-      <dd className="text-xs text-gray-900 text-right">{value ?? <span className="text-gray-400">N/A</span>}</dd>
+      <dd className="text-xs text-gray-900 text-right">
+        {value ?? <span className="text-gray-400">N/A</span>}
+      </dd>
     </div>
   );
 }
@@ -98,8 +100,18 @@ export function DocumentProcessingPanel({
           className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-orange-600 hover:text-orange-700"
         >
           View extracted content
-          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+          <svg
+            className="h-3.5 w-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+            />
           </svg>
         </button>
       )}

--- a/apps/web/src/components/documents/DocumentRow.tsx
+++ b/apps/web/src/components/documents/DocumentRow.tsx
@@ -34,8 +34,18 @@ export function DocumentRow({ document: doc, accessToken, onDeleted }: DocumentR
   return (
     <div className="flex items-center gap-3 py-3 px-1 group">
       <div className="flex-shrink-0">
-        <svg className="h-7 w-7 text-gray-400" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+        <svg
+          className="h-7 w-7 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+          />
         </svg>
       </div>
       <div className="flex-1 min-w-0">
@@ -49,8 +59,18 @@ export function DocumentRow({ document: doc, accessToken, onDeleted }: DocumentR
         className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-red-50 text-gray-400 hover:text-red-500 disabled:opacity-50"
         title="Delete document"
       >
-        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+          />
         </svg>
       </button>
     </div>

--- a/apps/web/src/components/documents/DocumentUpload.tsx
+++ b/apps/web/src/components/documents/DocumentUpload.tsx
@@ -62,7 +62,6 @@ export function DocumentUpload({ courseId, accessToken, onUploadComplete }: Docu
               updated[jobIndex] = { ...updated[jobIndex], progress: 'error', errorMessage: message };
             return updated;
           });
-          onUploadComplete?.();
         }
       }
     },

--- a/apps/web/src/components/documents/DocumentUpload.tsx
+++ b/apps/web/src/components/documents/DocumentUpload.tsx
@@ -41,7 +41,8 @@ export function DocumentUpload({ courseId, accessToken, onUploadComplete }: Docu
 
           setJobs((prev) => {
             const updated = [...prev];
-            if (updated[jobIndex]) updated[jobIndex] = { ...updated[jobIndex], progress: 'processing' };
+            if (updated[jobIndex])
+              updated[jobIndex] = { ...updated[jobIndex], progress: 'processing' };
             return updated;
           });
 
@@ -59,7 +60,11 @@ export function DocumentUpload({ courseId, accessToken, onUploadComplete }: Docu
           setJobs((prev) => {
             const updated = [...prev];
             if (updated[jobIndex])
-              updated[jobIndex] = { ...updated[jobIndex], progress: 'error', errorMessage: message };
+              updated[jobIndex] = {
+                ...updated[jobIndex],
+                progress: 'error',
+                errorMessage: message,
+              };
             return updated;
           });
         }
@@ -109,8 +114,18 @@ export function DocumentUpload({ courseId, accessToken, onUploadComplete }: Docu
             e.target.value = '';
           }}
         />
-        <svg className="mx-auto h-8 w-8 text-gray-400" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+        <svg
+          className="mx-auto h-8 w-8 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+          />
         </svg>
         <p className="mt-2 text-sm text-gray-600">
           <span className="font-medium text-orange-600">Click to upload</span> or drag and drop
@@ -123,8 +138,19 @@ export function DocumentUpload({ courseId, accessToken, onUploadComplete }: Docu
           {activeJobs.map((job, i) => (
             <div key={i} className="flex items-center gap-2 text-sm text-gray-600">
               <svg className="h-4 w-4 animate-spin text-orange-500" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
               </svg>
               <span className="truncate flex-1">{job.file.name}</span>
               <span className="text-xs text-gray-400 capitalize">{job.progress}</span>
@@ -137,8 +163,18 @@ export function DocumentUpload({ courseId, accessToken, onUploadComplete }: Docu
         <div className="mt-3 space-y-2">
           {errorJobs.map((job, i) => (
             <div key={i} className="flex items-center gap-2 rounded bg-red-50 px-3 py-2 text-sm">
-              <svg className="h-4 w-4 text-red-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+              <svg
+                className="h-4 w-4 text-red-500 flex-shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+                />
               </svg>
               <span className="truncate flex-1 text-red-700">{job.file.name}</span>
               <span className="text-xs text-red-500">{job.errorMessage}</span>

--- a/apps/web/src/components/study/ContentChunks.tsx
+++ b/apps/web/src/components/study/ContentChunks.tsx
@@ -107,10 +107,7 @@ export function ContentChunks({ courseId, accessToken, className }: ContentChunk
       <div className="space-y-6">
         {contents.map((doc) => (
           <div key={doc.documentId}>
-            <p
-              className="text-xs font-medium text-gray-600 mb-2 truncate"
-              title={doc.filename}
-            >
+            <p className="text-xs font-medium text-gray-600 mb-2 truncate" title={doc.filename}>
               {doc.filename}
             </p>
 

--- a/apps/web/src/components/study/LessonNav.tsx
+++ b/apps/web/src/components/study/LessonNav.tsx
@@ -29,9 +29,7 @@ export function LessonNav({
 
   if (lessons.length === 0) {
     return (
-      <div className="px-4 py-6 text-center text-sm text-gray-400">
-        No lessons available yet.
-      </div>
+      <div className="px-4 py-6 text-center text-sm text-gray-400">No lessons available yet.</div>
     );
   }
 
@@ -59,8 +57,8 @@ export function LessonNav({
                     isCompleted
                       ? 'bg-green-100 text-green-700'
                       : isSelected
-                      ? 'bg-orange-100 text-orange-700'
-                      : 'bg-gray-100 text-gray-500'
+                        ? 'bg-orange-100 text-orange-700'
+                        : 'bg-gray-100 text-gray-500'
                   }`}
                   aria-hidden="true"
                 >
@@ -72,15 +70,17 @@ export function LessonNav({
                       strokeWidth={2.5}
                       stroke="currentColor"
                     >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M4.5 12.75l6 6 9-13.5"
+                      />
                     </svg>
                   ) : (
                     index + 1
                   )}
                 </span>
-                <span className="flex-1 min-w-0 text-sm font-medium truncate">
-                  {lesson.title}
-                </span>
+                <span className="flex-1 min-w-0 text-sm font-medium truncate">{lesson.title}</span>
                 {isCompleted && (
                   <span className="flex-shrink-0 text-xs text-green-600 font-medium">Done</span>
                 )}

--- a/apps/web/src/components/study/OutputPane.tsx
+++ b/apps/web/src/components/study/OutputPane.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  useEffect,
-  useRef,
-  useState,
-  type KeyboardEvent,
-} from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { sendChatMessage, type Citation } from '@/lib/services/chat';
 import type { Lesson } from '@/lib/services/courses';
 
@@ -80,12 +75,8 @@ export function OutputPane({ courseId, accessToken, selectedLesson }: OutputPane
     <div className="h-full flex flex-col bg-white">
       {/* Header */}
       <div className="flex-shrink-0 px-6 py-4 border-b border-gray-200">
-        <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
-          AI Tutor
-        </h2>
-        <p className="mt-0.5 text-xs text-gray-500">
-          Ask questions about the course material
-        </p>
+        <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">AI Tutor</h2>
+        <p className="mt-0.5 text-xs text-gray-500">Ask questions about the course material</p>
       </div>
 
       {/* Message thread */}
@@ -107,54 +98,49 @@ export function OutputPane({ courseId, accessToken, selectedLesson }: OutputPane
                 />
               </svg>
               <p className="mt-3 text-sm text-gray-500">
-                Ask me anything about the course content. I will find relevant passages and explain them.
+                Ask me anything about the course content. I will find relevant passages and explain
+                them.
               </p>
             </div>
           </div>
         )}
 
         {messages.map((msg, i) => (
-          <div
-            key={i}
-            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
-          >
+          <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
             <div
               className={`max-w-[85%] rounded-xl px-4 py-3 ${
-                msg.role === 'user'
-                  ? 'bg-orange-600 text-white'
-                  : 'bg-gray-100 text-gray-900'
+                msg.role === 'user' ? 'bg-orange-600 text-white' : 'bg-gray-100 text-gray-900'
               }`}
             >
               <p className="text-sm whitespace-pre-wrap leading-relaxed">{msg.content}</p>
 
-              {msg.role === 'assistant' &&
-                msg.citations &&
-                msg.citations.length > 0 && (
-                  <div className="mt-3 space-y-2 border-t border-gray-200 pt-2">
-                    <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                      Sources
-                    </p>
-                    {msg.citations.map((citation, ci) => (
-                      <div
-                        key={ci}
-                        className="rounded-md bg-white border border-gray-200 px-3 py-2"
-                      >
-                        <p className="text-xs text-gray-700 line-clamp-3 leading-relaxed">
-                          &ldquo;{citation.snippet}&rdquo;
-                        </p>
-                        <p className="mt-1 text-xs text-gray-400">
-                          Relevance: {Math.round(citation.score * 100)}%
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                )}
+              {msg.role === 'assistant' && msg.citations && msg.citations.length > 0 && (
+                <div className="mt-3 space-y-2 border-t border-gray-200 pt-2">
+                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                    Sources
+                  </p>
+                  {msg.citations.map((citation, ci) => (
+                    <div key={ci} className="rounded-md bg-white border border-gray-200 px-3 py-2">
+                      <p className="text-xs text-gray-700 line-clamp-3 leading-relaxed">
+                        &ldquo;{citation.snippet}&rdquo;
+                      </p>
+                      <p className="mt-1 text-xs text-gray-400">
+                        Relevance: {Math.round(citation.score * 100)}%
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         ))}
 
         {loading && (
-          <div className="flex justify-start w-full" aria-label="Loading response" aria-live="polite">
+          <div
+            className="flex justify-start w-full"
+            aria-label="Loading response"
+            aria-live="polite"
+          >
             <div className="bg-gray-100 rounded-xl px-4 py-3 w-full max-w-[85%] space-y-2">
               <p className="text-xs text-gray-400 mb-1">Thinking…</p>
               <div className="h-3 rounded bg-gray-300 animate-pulse w-full" />
@@ -201,9 +187,7 @@ export function OutputPane({ courseId, accessToken, selectedLesson }: OutputPane
             </svg>
           </button>
         </div>
-        <p className="mt-1.5 text-xs text-gray-400">
-          Enter to send · Shift+Enter for a new line
-        </p>
+        <p className="mt-1.5 text-xs text-gray-400">Enter to send · Shift+Enter for a new line</p>
       </div>
     </div>
   );

--- a/apps/web/src/components/study/SourcePane.tsx
+++ b/apps/web/src/components/study/SourcePane.tsx
@@ -27,20 +27,14 @@ export function SourcePane({
   onMarkComplete,
   loadingLessons = false,
 }: SourcePaneProps) {
-  const isCompleted = selectedLesson
-    ? completedLessons.has(String(selectedLesson.id))
-    : false;
+  const isCompleted = selectedLesson ? completedLessons.has(String(selectedLesson.id)) : false;
 
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
       <div className="flex-shrink-0 px-6 py-4 border-b border-gray-200 bg-white">
-        <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
-          Study Path
-        </h2>
-        {courseTitle && (
-          <p className="mt-0.5 text-xs text-gray-500">{courseTitle}</p>
-        )}
+        <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">Study Path</h2>
+        {courseTitle && <p className="mt-0.5 text-xs text-gray-500">{courseTitle}</p>}
       </div>
 
       {/* Lesson list — capped height so content is still visible */}
@@ -58,9 +52,7 @@ export function SourcePane({
       <div className="flex-1 overflow-y-auto bg-gray-50">
         {selectedLesson ? (
           <div className="p-6 space-y-4">
-            <h3 className="text-base font-semibold text-gray-900">
-              {selectedLesson.title}
-            </h3>
+            <h3 className="text-base font-semibold text-gray-900">{selectedLesson.title}</h3>
 
             {selectedLesson.content && (
               <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">
@@ -69,11 +61,7 @@ export function SourcePane({
             )}
 
             {/* Document chunks from uploaded course material */}
-            <ContentChunks
-              courseId={courseId}
-              accessToken={accessToken}
-              className="mt-2"
-            />
+            <ContentChunks courseId={courseId} accessToken={accessToken} className="mt-2" />
 
             {/* Completion button */}
             <div className="pt-2">
@@ -116,9 +104,7 @@ export function SourcePane({
                   d="M4.26 10.147a60.438 60.438 0 00-.491 6.347A48.62 48.62 0 0112 20.904a48.62 48.62 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.636 50.636 0 00-2.658-.813A59.906 59.906 0 0112 3.493a59.903 59.903 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0112 13.489a50.702 50.702 0 017.74-3.342"
                 />
               </svg>
-              <h3 className="mt-4 text-sm font-medium text-gray-900">
-                Select a lesson to begin
-              </h3>
+              <h3 className="mt-4 text-sm font-medium text-gray-900">Select a lesson to begin</h3>
               <p className="mt-1 text-sm text-gray-500">
                 Choose a lesson from the list above to view its content and start studying.
               </p>

--- a/apps/web/src/components/ui/BadgeDisplay.tsx
+++ b/apps/web/src/components/ui/BadgeDisplay.tsx
@@ -23,9 +23,7 @@ export function BadgeDisplay({ badge, size = 'md' }: BadgeDisplayProps) {
       </span>
       <div>
         <p className="text-xs font-semibold text-yellow-800">{badge.name}</p>
-        {size === 'md' && (
-          <p className="text-xs text-yellow-600">{badge.description}</p>
-        )}
+        {size === 'md' && <p className="text-xs text-yellow-600">{badge.description}</p>}
       </div>
     </div>
   );

--- a/apps/web/src/components/ui/ProgressBar.tsx
+++ b/apps/web/src/components/ui/ProgressBar.tsx
@@ -24,9 +24,7 @@ export function ProgressBar({
       {(label || showPercent) && (
         <div className="flex justify-between items-center mb-1">
           {label && <span className="text-xs text-gray-500">{label}</span>}
-          {showPercent && (
-            <span className="text-xs font-medium text-gray-700">{clamped}%</span>
-          )}
+          {showPercent && <span className="text-xs font-medium text-gray-700">{clamped}%</span>}
         </div>
       )}
       <div

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -32,10 +32,7 @@ async function handleResponse<T>(response: Response): Promise<T> {
   return response.json();
 }
 
-export async function apiFetch<T>(
-  endpoint: string,
-  options: FetchOptions = {}
-): Promise<T> {
+export async function apiFetch<T>(endpoint: string, options: FetchOptions = {}): Promise<T> {
   const { body, accessToken, headers: customHeaders, ...rest } = options;
 
   const headers: Record<string, string> = {

--- a/apps/web/src/lib/api/adapters.ts
+++ b/apps/web/src/lib/api/adapters.ts
@@ -6,7 +6,6 @@ import type {
   DocumentDetailView,
   DocumentPreviewView,
   DocumentStatus,
-  ProcessingStage,
 } from './types';
 
 function mimeToLabel(mime: string | null, filename: string): string {

--- a/apps/web/src/lib/api/courses.ts
+++ b/apps/web/src/lib/api/courses.ts
@@ -4,30 +4,27 @@ import type { ApiCourse, ApiLesson, CreateCourseRequest } from './types';
 export async function fetchCourses(
   skip = 0,
   limit = 100,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<ApiCourse[]> {
   return apiFetch<ApiCourse[]>(`/courses?skip=${skip}&limit=${limit}`, {
     accessToken,
   });
 }
 
-export async function fetchCourse(
-  courseId: string,
-  accessToken?: string,
-): Promise<ApiCourse> {
+export async function fetchCourse(courseId: string, accessToken?: string): Promise<ApiCourse> {
   return apiFetch<ApiCourse>(`/courses/${courseId}`, { accessToken });
 }
 
 export async function fetchCourseLessons(
   courseId: string,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<ApiLesson[]> {
   return apiFetch<ApiLesson[]>(`/courses/${courseId}/lessons`, { accessToken });
 }
 
 export async function createCourse(
   data: CreateCourseRequest,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<ApiCourse> {
   return apiFetch<ApiCourse>('/courses', {
     method: 'POST',

--- a/apps/web/src/lib/api/documents.ts
+++ b/apps/web/src/lib/api/documents.ts
@@ -14,7 +14,7 @@ import { toDocumentListRow, toDocumentDetailView, toDocumentPreviewView } from '
 
 export async function fetchDocumentsList(
   courseId: string,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<ApiDocumentListItem[]> {
   return apiFetch<ApiDocumentListItem[]>(`/courses/${courseId}/documents`, {
     accessToken,
@@ -23,7 +23,7 @@ export async function fetchDocumentsList(
 
 export async function fetchDocumentStatus(
   documentId: string,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<ApiDocumentStatusResponse> {
   return apiFetch<ApiDocumentStatusResponse>(`/documents/${documentId}/status`, {
     accessToken,
@@ -32,7 +32,7 @@ export async function fetchDocumentStatus(
 
 export async function fetchDocumentDetail(
   documentId: string,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<ApiDocumentDetail> {
   return apiFetch<ApiDocumentDetail>(`/documents/${documentId}`, {
     accessToken,
@@ -41,7 +41,7 @@ export async function fetchDocumentDetail(
 
 export async function fetchDocumentPreview(
   documentId: string,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<ApiDocumentPreview> {
   return apiFetch<ApiDocumentPreview>(`/documents/${documentId}/preview`, {
     accessToken,
@@ -51,7 +51,7 @@ export async function fetchDocumentPreview(
 export async function uploadDocument(
   courseId: string,
   file: File,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<ApiDocumentListItem> {
   const formData = new FormData();
   formData.append('file', file);
@@ -64,7 +64,7 @@ export async function uploadDocument(
 
 export async function deleteDocument(
   documentId: string,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<{ message: string }> {
   return apiFetch<{ message: string }>(`/documents/${documentId}`, {
     method: 'DELETE',
@@ -76,7 +76,7 @@ export async function deleteDocument(
 
 export async function getDocumentListRows(
   courseId: string,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<DocumentListRow[]> {
   const items = await fetchDocumentsList(courseId, accessToken);
   return items.map(toDocumentListRow);
@@ -84,7 +84,7 @@ export async function getDocumentListRows(
 
 export async function getDocumentDetailView(
   documentId: string,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<DocumentDetailView> {
   const item = await fetchDocumentDetail(documentId, accessToken);
   return toDocumentDetailView(item);
@@ -92,7 +92,7 @@ export async function getDocumentDetailView(
 
 export async function getDocumentPreviewView(
   documentId: string,
-  accessToken?: string,
+  accessToken?: string
 ): Promise<DocumentPreviewView> {
   const item = await fetchDocumentPreview(documentId, accessToken);
   return toDocumentPreviewView(item);
@@ -104,7 +104,7 @@ export async function pollDocumentUntilTerminal(
   documentId: string,
   accessToken?: string,
   intervalMs = 3000,
-  maxAttempts = 60,
+  maxAttempts = 60
 ): Promise<ApiDocumentStatusResponse> {
   for (let i = 0; i < maxAttempts; i++) {
     try {

--- a/apps/web/src/lib/services/courses.ts
+++ b/apps/web/src/lib/services/courses.ts
@@ -16,33 +16,20 @@ export interface CourseWithLessons extends Course {
   lessons: Lesson[];
 }
 
-export async function getCourses(
-  skip = 0,
-  limit = 100,
-  accessToken?: string
-): Promise<Course[]> {
+export async function getCourses(skip = 0, limit = 100, accessToken?: string): Promise<Course[]> {
   return apiFetch<Course[]>(`/courses?skip=${skip}&limit=${limit}`, {
     accessToken,
   });
 }
 
-export async function getCourse(
-  courseId: string,
-  accessToken?: string
-): Promise<Course> {
+export async function getCourse(courseId: string, accessToken?: string): Promise<Course> {
   return apiFetch<Course>(`/courses/${courseId}`, { accessToken });
 }
 
-export async function getCourseLessons(
-  courseId: string,
-  accessToken?: string
-): Promise<Lesson[]> {
+export async function getCourseLessons(courseId: string, accessToken?: string): Promise<Lesson[]> {
   return apiFetch<Lesson[]>(`/courses/${courseId}/lessons`, { accessToken });
 }
 
-export async function getLesson(
-  lessonId: string,
-  accessToken?: string
-): Promise<Lesson> {
+export async function getLesson(lessonId: string, accessToken?: string): Promise<Lesson> {
   return apiFetch<Lesson>(`/lessons/${lessonId}`, { accessToken });
 }

--- a/apps/web/src/types/next-auth.d.ts
+++ b/apps/web/src/types/next-auth.d.ts
@@ -1,0 +1,12 @@
+import type { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      accessToken: string;
+      refreshToken: string;
+      role: string;
+      displayName: string | null;
+    } & DefaultSession['user'];
+  }
+}


### PR DESCRIPTION
Closes #7

## Contesto

Audit completo del frontend esistente: l'unica issue aperta è la #7 (Frontend Authentication). Le pagine esistono già ma contengono bug concreti. L'audit ha rilevato ulteriori problemi nelle componenti già implementate.

## Modifiche per gruppo

### A · Issue #7 — Auth pages
- **Signup**: validazione password allineata al backend (`auth_schemas.py`) — minimo 12 caratteri (era 8) + carattere speciale aggiunto
- **Signup**: gestione errori FastAPI 422 — `detail` può essere array, viene ora estratto correttamente
- **Login**: `result.error === "CredentialsSignin"` mappato a messaggio user-friendly invece di essere mostrato raw
- **Login**: parametro `?message=` letto e mostrato come banner info (usato dal redirect post-registrazione)
- **Login**: aggiunto `<Suspense>` boundary richiesto da Next.js 14 per `useSearchParams()` durante la static generation

### B · Session type safety
- Nuovo file `src/types/next-auth.d.ts` che estende `Session["user"]` con `accessToken`, `refreshToken`, `role`, `displayName`
- Rimossi tutti i cast `(session?.user as any)` in dashboard, courses, course workspace, study page

### C · DocumentUpload callback
- `onUploadComplete?.()` veniva chiamato anche nel blocco `catch`, facendo ricaricare i documenti al parent anche dopo un upload fallito — rimosso dal catch

### D · Dashboard stats
- "Courses Completed" e "Certificates Earned" erano hardcoded a `0` senza dati reali dal backend — rimossi per evitare di mostrare dati fuorvianti

### E · ProcessingIndicator
- Il label della stage era gated su `status === 'processing'`, impedendo di mostrarlo durante `status === 'uploading'` — condizione rimossa

### Style
- Prettier applicato a tutti i file `src/**/*.{ts,tsx}` (errori di formattazione pre-esistenti)
- Rimossa import `ProcessingStage` non usata in `adapters.ts` (bloccava il build)

## Verifica

- ✅ `tsc --noEmit` — zero errori TypeScript
- ✅ `next lint` — zero errori nei file modificati
- ✅ `next build` — build production completata (9/9 pagine generate)