### PR TITLE
feat: implement study actions

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -12,7 +12,8 @@
         "next-auth": "^4.24.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-markdown": "^7.1.2"
+        "react-markdown": "^7.1.2",
+        "remark-gfm": "^3.0.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.0",
@@ -3712,6 +3713,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -7942,6 +7953,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8000,6 +8021,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8023,6 +8054,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -8049,6 +8108,114 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
+      "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-gfm-autolink-literal": "^1.0.0",
+        "mdast-util-gfm-footnote": "^1.0.0",
+        "mdast-util-gfm-strikethrough": "^1.0.0",
+        "mdast-util-gfm-table": "^1.0.0",
+        "mdast-util-gfm-task-list-item": "^1.0.0",
+        "mdast-util-to-markdown": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
+      "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "ccount": "^2.0.0",
+        "mdast-util-find-and-replace": "^2.0.0",
+        "micromark-util-character": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
+      "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "micromark-util-normalize-identifier": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
+      "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
+      "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-11.3.0.tgz",
@@ -8064,6 +8231,26 @@
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8173,6 +8360,127 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
+      "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^1.0.0",
+        "micromark-extension-gfm-footnote": "^1.0.0",
+        "micromark-extension-gfm-strikethrough": "^1.0.0",
+        "micromark-extension-gfm-table": "^1.0.0",
+        "micromark-extension-gfm-tagfilter": "^1.0.0",
+        "micromark-extension-gfm-task-list-item": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
+      "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
+      "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-core-commonmark": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
+      "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
+      "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
+      "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -9923,6 +10231,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
+      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-gfm": "^2.0.0",
+        "micromark-extension-gfm": "^2.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-parse": {
@@ -11910,6 +12234,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,8 @@
     "next-auth": "^4.24.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-markdown": "^7.1.2"
+    "react-markdown": "^7.1.2",
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.0",

--- a/apps/web/src/components/study/OutputPane.tsx
+++ b/apps/web/src/components/study/OutputPane.tsx
@@ -2,9 +2,11 @@
 
 import Link from 'next/link';
 import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { useToast } from '@/components/ui/Toast';
 import { sendChatMessageStream, submitFeedback, type Citation, type HistoryEntry } from '@/lib/services/chat';
-import { sendStudyAction } from '@/lib/services/study';
+import { sendStudyAction, sendStudyActionStream } from '@/lib/services/study';
 import type { ApiCitationOut, ApiStudyResponse, StudyAction } from '@/lib/api/types';
 import type { Lesson } from '@/lib/services/courses';
 import { StudyActionBar } from './StudyActionBar';
@@ -27,7 +29,17 @@ interface ActionMessage {
   durationMs?: number;
 }
 
-type Message = ChatMessage | ActionMessage;
+interface ActionStreamingMessage {
+  role: 'action-streaming';
+  action: StudyAction;
+  query: string;
+  content: string;
+}
+
+type Message = ChatMessage | ActionMessage | ActionStreamingMessage;
+
+// Actions that stream tokens progressively (full text needed for QUIZ/ORAL parsing).
+const STREAMING_ACTIONS = new Set<StudyAction>(['explain', 'summarize', 'derive', 'compare', 'open_questions']);
 
 interface OutputPaneProps {
   courseId: string;
@@ -231,7 +243,11 @@ function loadStoredMessages(courseId: string): Message[] {
 
 function saveMessages(courseId: string, msgs: Message[]) {
   try {
-    const toSave = msgs.slice(-STORAGE_MAX_MESSAGES);
+    // Exclude in-flight streaming messages — they have no `result` field and would
+    // crash on restore if any code path accesses msg.result.
+    const toSave = msgs
+      .filter((m) => m.role !== 'action-streaming')
+      .slice(-STORAGE_MAX_MESSAGES);
     localStorage.setItem(`${STORAGE_PREFIX}${courseId}`, JSON.stringify(toSave));
   } catch {
     /* storage unavailable */
@@ -262,6 +278,8 @@ export function OutputPane({
   // Captures the index of the in-flight assistant message inside the functional
   // setMessages updater so it stays correct across React's concurrent-mode batching.
   const assistantIdxRef = useRef(-1);
+  // Index of the in-flight action-streaming message (set when first token arrives).
+  const streamingActionIdxRef = useRef(-1);
   const [retryQuestion, setRetryQuestion] = useState<string | null>(null);
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
   const { showToast } = useToast();
@@ -368,6 +386,85 @@ export function OutputPane({
     setSessionRestored(false);
     setMessages((prev) => [...prev, { role: 'user', content: `[${action}] ${query}` }]);
     const t0 = Date.now();
+
+    // Streaming path: EXPLAIN, SUMMARIZE, DERIVE, COMPARE, OPEN_QUESTIONS stream tokens.
+    // Loading spinner stays until first token; then replaced by progressive streaming message.
+    if (STREAMING_ACTIONS.has(action) && !ragOnly) {
+      let streamingCitations: ApiCitationOut[] = [];
+      streamingActionIdxRef.current = -1;
+
+      try {
+        await sendStudyActionStream(
+          courseId,
+          action,
+          query,
+          (token) => {
+            setMessages((prev) => {
+              if (streamingActionIdxRef.current === -1) {
+                // First token: stop loading spinner, add streaming message
+                streamingActionIdxRef.current = prev.length;
+                return [...prev, { role: 'action-streaming', action, query, content: token }];
+              }
+              return prev.map((m, i) =>
+                i === streamingActionIdxRef.current && m.role === 'action-streaming'
+                  ? { ...m, content: m.content + token }
+                  : m
+              );
+            });
+            // Stop the loading skeleton once streaming begins
+            setLoading(false);
+          },
+          (citations) => {
+            streamingCitations = citations;
+          },
+          accessToken,
+          ragOnly,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Study action failed.';
+        if (msg.includes('Troppe richieste')) showToast('Troppe richieste — riprova tra qualche secondo.', 'warn');
+        setMessages((prev) => [...prev, { role: 'assistant', content: `Error: ${msg}` }]);
+        setLoading(false);
+        setActiveAction(null);
+        return;
+      }
+
+      const durationMs = Date.now() - t0;
+
+      // Replace action-streaming message with final action-result
+      let finalResult: ApiStudyResponse | null = null;
+      setMessages((prev) => {
+        const idx = streamingActionIdxRef.current;
+        const streamMsg = idx >= 0 ? prev[idx] : null;
+        const answer = streamMsg?.role === 'action-streaming' ? streamMsg.content : '';
+
+        if (!answer) {
+          return [...prev, { role: 'assistant' as const, content: 'No response received.' }];
+        }
+
+        finalResult = {
+          answer,
+          citations: streamingCitations,
+          retrieval_used: streamingCitations.length > 0,
+          action,
+        };
+
+        return prev.map((m, i) =>
+          i === idx
+            ? ({ role: 'action-result', action, query, result: finalResult!, durationMs } as ActionMessage)
+            : m
+        );
+      });
+
+      if (streamingCitations.length > 0) setShowEvidence(true);
+      // Notify parent (lesson progress, analytics) — same contract as buffered path.
+      if (finalResult) onActionResult?.(finalResult, selectedLesson ?? null);
+      setLoading(false);
+      setActiveAction(null);
+      return;
+    }
+
+    // Buffered path: QUIZ, ORAL, RETRIEVE, or ragOnly (need full text before parsing).
     try {
       const result = await sendStudyAction(courseId, action, query, accessToken, ragOnly);
       const durationMs = Date.now() - t0;
@@ -509,7 +606,7 @@ export function OutputPane({
             <div className="text-center max-w-xs">
               <div className="mx-auto w-10 h-10 b-thin rounded-md mb-4 stripes" />
               <p className="font-mono text-[11px] opacity-60 leading-relaxed mb-4">
-                Scrivi un argomento qui sotto e scegli un'azione di studio — o fai una domanda libera.
+                Scrivi un argomento qui sotto e scegli un&apos;azione di studio — o fai una domanda libera.
               </p>
               <div className="flex flex-wrap justify-center gap-2">
                 {(['summarize', 'explain', 'quiz'] as const).map((a) => (
@@ -529,6 +626,23 @@ export function OutputPane({
 
         {messages.map((msg, i) => {
           const isLast = i === messages.length - 1;
+
+          if (msg.role === 'action-streaming') {
+            return (
+              <div key={i} className="space-y-2">
+                <div className="inline-flex items-center gap-1.5">
+                  <span className="chip" style={{ border: '1px solid currentColor' }}>
+                    {msg.action.replace('_', ' ')}
+                  </span>
+                  <span className="font-mono text-[11px] opacity-60 truncate max-w-48">{msg.query}</span>
+                  <span className="font-mono text-[10px] opacity-40 animate-pulse ml-1">…</span>
+                </div>
+                <div className="b-thin rounded-lg p-4">
+                  <ReactMarkdown className="md-prose" remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
+                </div>
+              </div>
+            );
+          }
 
           if (msg.role === 'action-result') {
             return (
@@ -557,7 +671,6 @@ export function OutputPane({
                   <StudyOutput
                     result={msg.result}
                     courseId={courseId}
-                    onOralFollowUp={(query) => handleAction('oral', query)}
                   />
                 </div>
 

--- a/apps/web/src/components/study/StudyOutput.tsx
+++ b/apps/web/src/components/study/StudyOutput.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import type { ApiStudyResponse } from '@/lib/api/types';
 import { CitationCard } from './CitationCard';
 
@@ -34,10 +35,9 @@ function CopyButton({ text }: { text: string }) {
 interface StudyOutputProps {
   result: ApiStudyResponse;
   courseId: string;
-  onOralFollowUp?: (query: string) => void;
 }
 
-export function StudyOutput({ result, courseId, onOralFollowUp }: StudyOutputProps) {
+export function StudyOutput({ result, courseId }: StudyOutputProps) {
   const [showSources, setShowSources] = useState(result.action === 'retrieve');
 
   const hasOutput = result.answer && result.answer.trim().length > 0;
@@ -51,12 +51,22 @@ export function StudyOutput({ result, courseId, onOralFollowUp }: StudyOutputPro
         </p>
       )}
 
+      {/* Retrieval unavailable — no citations returned for an action that requires them */}
+      {!hasCitations && !result.retrieval_used && result.action !== 'retrieve' && hasOutput && (
+        <div
+          className="b-thin rounded-md px-4 py-3 text-sm"
+          style={{ borderColor: '#a55a00', color: '#a55a00' }}
+        >
+          Retrieval service temporarily unavailable. Response generated without source context — verify facts independently.
+        </div>
+      )}
+
       {!hasOutput && hasCitations && result.action !== 'retrieve' && (
         <div
           className="b-thin rounded-md px-4 py-3 text-sm"
           style={{ borderColor: '#a55a00', color: '#a55a00' }}
         >
-          LLM generation unavailable (OPENAI_API_KEY not configured). Showing source passages below.
+          LLM generation unavailable. Showing source passages below.
         </div>
       )}
 
@@ -68,11 +78,11 @@ export function StudyOutput({ result, courseId, onOralFollowUp }: StudyOutputPro
           {result.action === 'quiz' ? (
             <QuizOutput text={result.answer} />
           ) : result.action === 'oral' ? (
-            <OralOutput text={result.answer} onSubmit={onOralFollowUp} />
+            <OralOutput text={result.answer} />
           ) : result.action === 'open_questions' ? (
             <QuestionsOutput text={result.answer} />
           ) : (
-            <ReactMarkdown className="md-prose">{result.answer}</ReactMarkdown>
+            <ReactMarkdown className="md-prose" remarkPlugins={[remarkGfm]}>{result.answer}</ReactMarkdown>
           )}
         </div>
       )}
@@ -124,6 +134,7 @@ interface ParsedQuestion {
   question: string;
   options: string[];
   correctLetter: string;
+  explanation: string;
 }
 
 function parseQuizQuestion(raw: string): ParsedQuestion {
@@ -136,19 +147,22 @@ function parseQuizQuestion(raw: string): ParsedQuestion {
   const options = lines.filter((l) => /^[A-D][).]\s/.test(l));
   const answerLine = lines.find((l) => /^Answer:/i.test(l));
   const correctLetter = answerLine
-    ? answerLine
-        .replace(/^Answer:\s*/i, '')
-        .trim()
-        .charAt(0)
-        .toUpperCase()
+    ? answerLine.replace(/^Answer:\s*/i, '').trim().charAt(0).toUpperCase()
     : '';
-  return { question, options, correctLetter };
+  // Extract explanation: text after "Answer: B) " and before any [ref_N]
+  const explanation = answerLine
+    ? answerLine
+        .replace(/^Answer:\s*[A-D][).]\s*/i, '')
+        .replace(/\[ref_\d+\]/gi, '')
+        .trim()
+    : '';
+  return { question, options, correctLetter, explanation };
 }
 
 function QuizQuestion({ raw, index }: { raw: string; index: number }) {
   const [selected, setSelected] = useState('');
   const [revealed, setRevealed] = useState(false);
-  const { question, options, correctLetter } = useMemo(() => parseQuizQuestion(raw), [raw]);
+  const { question, options, correctLetter, explanation } = useMemo(() => parseQuizQuestion(raw), [raw]);
 
   return (
     <div className="b-thin rounded-lg p-4 bg-white dark:bg-blue-dark/20">
@@ -205,6 +219,13 @@ function QuizQuestion({ raw, index }: { raw: string; index: number }) {
               </p>
             )}
           </div>
+
+          {/* Rationale shown after reveal */}
+          {revealed && explanation && (
+            <p className="mt-2 text-[12px] leading-snug opacity-70 border-t border-current/10 pt-2">
+              {explanation}
+            </p>
+          )}
         </div>
       ) : (
         /* Fallback: options not parseable — show plain reveal */
@@ -223,6 +244,9 @@ function QuizQuestion({ raw, index }: { raw: string; index: number }) {
               <p className="font-mono text-[12px]" style={{ color: '#1a7f3a' }}>
                 Answer: {correctLetter}
               </p>
+              {explanation && (
+                <p className="mt-1 text-[12px] leading-snug opacity-70">{explanation}</p>
+              )}
             </div>
           )}
         </div>
@@ -232,7 +256,8 @@ function QuizQuestion({ raw, index }: { raw: string; index: number }) {
 }
 
 function QuizOutput({ text }: { text: string }) {
-  const questions = text.split(/\n(?=Q:)/g).filter((s) => s.trim());
+  // Both alternatives accept Q<n>: and Q<n>. to handle LLM format variance.
+  const questions = text.split(/\n\s*\n(?=Q\d*[:.])|\n(?=Q\d*[:.] )/g).filter((s) => s.trim());
   if (questions.length === 0) {
     return (
       <pre className="whitespace-pre-wrap font-sans text-[13.5px] leading-relaxed">{text}</pre>
@@ -249,51 +274,124 @@ function QuizOutput({ text }: { text: string }) {
 
 // ── Oral ──────────────────────────────────────────────────────────────────────
 
-function OralOutput({ text, onSubmit }: { text: string; onSubmit?: (query: string) => void }) {
-  const [answers, setAnswers] = useState<Record<number, string>>({});
-  const questions = text.split(/\n(?=Q\d+:)/g).filter((s) => s.trim());
+interface OralQuestion {
+  question: string;
+  modelAnswer: string;
+  followUp: string;
+}
 
-  function handleSubmit(idx: number, questionText: string) {
-    const answer = (answers[idx] ?? '').trim();
-    if (!answer || !onSubmit) return;
-    onSubmit(`${questionText.trim()}\n\nMy answer: ${answer}`);
-  }
+// Labels the ORAL system prompt mandates; plus common LLM deviations.
+const _MODEL_ANSWER_RE =
+  /(?:Model\s+answer|Model\s+risposta|Answer|Risposta(?:\s+del\s+modello)?):\s*([\s\S]*?)(?:\n(?:Follow-?up|Follow\s+up|Deeper\s+(?:question|probe)|Domanda\s+(?:di\s+)?approfondimento|Approfondimento):|$)/i;
+const _FOLLOW_UP_RE =
+  /(?:Follow-?up|Follow\s+up|Deeper\s+(?:question|probe)|Domanda\s+(?:di\s+)?approfondimento|Approfondimento):\s*([\s\S]*?)(?:\n(?:Q\d+:|$))/i;
 
-  function answerBox(idx: number, questionText: string) {
-    return (
-      <div className="mt-3 space-y-2">
-        <textarea
-          value={answers[idx] ?? ''}
-          onChange={(e) => setAnswers((prev) => ({ ...prev, [idx]: e.target.value }))}
-          placeholder="Type your answer here…"
-          rows={3}
-          className="w-full resize-none rounded-md b-thin px-3 py-2 text-sm bg-transparent outline-none focus:ring-1 focus:ring-blue-dark"
-        />
-        {(answers[idx] ?? '').trim() && onSubmit && (
-          <button onClick={() => handleSubmit(idx, questionText)} className="btn-ghost text-[11px]">
-            Submit answer →
-          </button>
-        )}
-      </div>
-    );
-  }
+function parseOralOutput(text: string): OralQuestion[] {
+  // Accept Q<n>: and Q<n>. as block delimiters.
+  const blocks = text.split(/\n\s*\n(?=Q\d+[:.])|\n(?=Q\d+[:.])/g).filter((b) => b.trim());
+  if (blocks.length === 0) return [];
+
+  return blocks.map((block) => {
+    const lines = block.split('\n');
+    // Question: first line matching Q<n>: or Q<n>.
+    const qLine = lines.find((l) => /^Q\d+[:.]/i.test(l.trim())) ?? '';
+    const question = qLine.replace(/^Q\d+[:.]\s*/i, '').trim();
+
+    // Model answer: text between the answer label and the follow-up label (or end)
+    const modelAnswerMatch = block.match(_MODEL_ANSWER_RE);
+    const modelAnswer = modelAnswerMatch ? modelAnswerMatch[1].trim() : '';
+
+    // Follow-up: text after the follow-up label
+    const followUpMatch = block.match(_FOLLOW_UP_RE);
+    const followUp = followUpMatch ? followUpMatch[1].trim() : '';
+
+    return { question, modelAnswer, followUp };
+  });
+}
+
+type OralPhase = 'idle' | 'submitted' | 'revealed';
+
+function OralQuestionCard({ q, index }: { q: OralQuestion; index: number }) {
+  const [phase, setPhase] = useState<OralPhase>('idle');
+  const [studentAnswer, setStudentAnswer] = useState('');
+
+  return (
+    <div className="b-thin rounded-lg p-4 bg-white dark:bg-blue-dark/20 space-y-3">
+      <p className="font-mono text-[10px] tracking-[0.18em] uppercase opacity-50">Q{index + 1}</p>
+      <p className="text-[13.5px] font-medium leading-snug">{q.question}</p>
+
+      {phase === 'idle' && (
+        <div className="space-y-2">
+          <textarea
+            value={studentAnswer}
+            onChange={(e) => setStudentAnswer(e.target.value)}
+            placeholder="Type your answer here…"
+            rows={3}
+            className="w-full resize-none rounded-md b-thin px-3 py-2 text-sm bg-transparent outline-none focus:ring-1 focus:ring-blue-dark"
+          />
+          {studentAnswer.trim() && (
+            <button
+              onClick={() => setPhase('submitted')}
+              className="btn-ghost text-[11px]"
+            >
+              Submit answer →
+            </button>
+          )}
+        </div>
+      )}
+
+      {phase !== 'idle' && (
+        <div className="b-thin rounded-md px-3 py-2 bg-blue-dark/5 dark:bg-white/5">
+          <p className="font-mono text-[10px] tracking-[0.18em] uppercase opacity-50 mb-1">Your answer</p>
+          <p className="text-[13px] leading-snug">{studentAnswer}</p>
+        </div>
+      )}
+
+      {phase === 'submitted' && (
+        <button
+          onClick={() => setPhase('revealed')}
+          className="btn-ghost text-[11px]"
+        >
+          See model answer ▾
+        </button>
+      )}
+
+      {phase === 'revealed' && q.modelAnswer && (
+        <div className="space-y-2">
+          <div
+            className="b-thin rounded-md px-3 py-2"
+            style={{ borderColor: '#1a7f3a', background: 'rgba(26,127,58,0.05)' }}
+          >
+            <p className="font-mono text-[10px] tracking-[0.18em] uppercase mb-1" style={{ color: '#1a7f3a' }}>
+              Model answer
+            </p>
+            <p className="text-[13px] leading-snug">{q.modelAnswer}</p>
+          </div>
+          {q.followUp && (
+            <div className="b-thin rounded-md px-3 py-2 bg-blue-dark/5 dark:bg-white/5">
+              <p className="font-mono text-[10px] tracking-[0.18em] uppercase opacity-50 mb-1">Follow-up</p>
+              <p className="text-[13px] leading-snug italic">{q.followUp}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OralOutput({ text }: { text: string }) {
+  const questions = useMemo(() => parseOralOutput(text), [text]);
 
   if (questions.length === 0) {
     return (
-      <div>
-        <ReactMarkdown className="md-prose">{text}</ReactMarkdown>
-        {answerBox(0, text)}
-      </div>
+      <ReactMarkdown className="md-prose" remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
     );
   }
 
   return (
     <div className="space-y-4">
       {questions.map((q, i) => (
-        <div key={i} className="b-thin rounded-lg p-4 bg-white dark:bg-blue-dark/20">
-          <ReactMarkdown className="md-prose">{q.trim()}</ReactMarkdown>
-          {answerBox(i, q)}
-        </div>
+        <OralQuestionCard key={i} q={q} index={i} />
       ))}
     </div>
   );

--- a/apps/web/src/lib/services/study.ts
+++ b/apps/web/src/lib/services/study.ts
@@ -1,5 +1,5 @@
-import { apiFetch } from '@/lib/api';
-import type { ApiStudyRequest, ApiStudyResponse, StudyAction } from '@/lib/api/types';
+import { apiFetch, API_BASE_URL } from '@/lib/api';
+import type { ApiCitationOut, ApiStudyRequest, ApiStudyResponse, StudyAction } from '@/lib/api/types';
 
 export type { StudyAction, ApiStudyResponse as StudyResponse };
 
@@ -16,4 +16,75 @@ export async function sendStudyAction(
     body,
     accessToken,
   });
+}
+
+const CITATIONS_SENTINEL = '\x00CITATIONS\x00';
+
+/**
+ * Streams a study action via SSE from /courses/{courseId}/study/stream.
+ *
+ * Tokens are delivered to onToken as they arrive. After the last token the
+ * backend emits a citations sentinel; onCitations is called with the parsed
+ * citation array. The function resolves when the [DONE] marker is received.
+ */
+export async function sendStudyActionStream(
+  courseId: string,
+  action: StudyAction,
+  query: string,
+  onToken: (token: string) => void,
+  onCitations: (citations: ApiCitationOut[]) => void,
+  accessToken?: string,
+  ragOnly?: boolean,
+): Promise<void> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (accessToken) headers['Authorization'] = `Bearer ${accessToken}`;
+
+  const body: ApiStudyRequest = { action, query, ...(ragOnly ? { rag_only: true } : {}) };
+
+  const response = await fetch(`${API_BASE_URL}/courses/${courseId}/study/stream`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const msg = response.status === 429 ? 'Troppe richieste — riprova tra qualche secondo.' : `Stream request failed (${response.status})`;
+    throw new Error(msg);
+  }
+  if (!response.body) throw new Error('Stream response body is null');
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      const payload = line.slice(6);
+      if (payload === '[DONE]') return;
+
+      let token: string;
+      try {
+        token = JSON.parse(payload) as string;
+      } catch {
+        token = payload;
+      }
+
+      if (token.startsWith(CITATIONS_SENTINEL)) {
+        try {
+          onCitations(JSON.parse(token.slice(CITATIONS_SENTINEL.length)) as ApiCitationOut[]);
+        } catch { /* ignore malformed citations */ }
+        continue;
+      }
+
+      onToken(token);
+    }
+  }
 }

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     environment:
       - QVAC_PORT=3001
       - QVAC_INGEST_DIR=/qvac_ingest
+      # 8192-token context (course builder); set 4096 to fit a 4g memory limit.
+      - QVAC_LLM_CTX=${QVAC_LLM_CTX:-8192}
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3001/health || exit 1"]
       interval: 15s
@@ -43,7 +45,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4g
+          memory: 5g
           cpus: '4'
 
   redis:

--- a/services/ai/alembic/versions/0003_section_tree.py
+++ b/services/ai/alembic/versions/0003_section_tree.py
@@ -1,0 +1,26 @@
+"""add course_document.section_tree_json
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-06-11
+
+Nested heading tree (title, level, page span, parent-chunk anchors) extracted
+at ingest — structure source for course builder outline generation (Fase 1).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("course_document", sa.Column("section_tree_json", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("course_document", "section_tree_json")

--- a/services/ai/alembic/versions/0004_course_builder.py
+++ b/services/ai/alembic/versions/0004_course_builder.py
@@ -1,0 +1,47 @@
+"""course builder — Chapter/Lesson status, source_refs, GenerationRun table
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-06-12
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Chapter status (draft | published)
+    op.add_column("chapter", sa.Column("status", sa.String(), nullable=True))
+    op.execute("UPDATE chapter SET status = 'published' WHERE status IS NULL")
+
+    # Lesson status + grounding anchor
+    op.add_column("lesson", sa.Column("status", sa.String(), nullable=True))
+    op.execute("UPDATE lesson SET status = 'published' WHERE status IS NULL")
+    op.add_column("lesson", sa.Column("source_refs_json", sa.Text(), nullable=True))
+
+    # Provenance table for outline / content generation jobs
+    op.create_table(
+        "generation_run",
+        sa.Column("id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("course_id", sa.String(), sa.ForeignKey("course.id"), nullable=False),
+        sa.Column("doc_ids_json", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("stage", sa.String(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("prompt_version", sa.String(), nullable=True),
+        sa.Column("started_at", sa.String(), nullable=True),
+        sa.Column("finished_at", sa.String(), nullable=True),
+        sa.Column("options_json", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.String(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("generation_run")
+    op.drop_column("lesson", "source_refs_json")
+    op.drop_column("lesson", "status")
+    op.drop_column("chapter", "status")

--- a/services/ai/alembic/versions/0005_lesson_content_hash.py
+++ b/services/ai/alembic/versions/0005_lesson_content_hash.py
@@ -1,0 +1,21 @@
+"""lesson content_hash for idempotent regeneration
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-06-12
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("lesson", sa.Column("content_hash", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lesson", "content_hash")

--- a/services/ai/app/api/content_api.py
+++ b/services/ai/app/api/content_api.py
@@ -1,0 +1,246 @@
+"""Content API — course builder phase 3.
+
+Endpoints:
+  POST /courses/{id}/content/generate  → enqueue lesson content generation job
+  POST /courses/{id}/publish           → publish all ready chapters/lessons
+  GET  /lessons/{id}/content           → lesson detail with content + quiz
+"""
+import json
+import uuid
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Path, Request
+from sqlalchemy.orm import Session
+
+from app.core.errors import NotFoundError, ValidationError_
+from app.db.models import (
+    Chapter,
+    DocumentStatus,
+    GenerationRun,
+    GenerationRunStatus,
+    Lesson,
+    Quiz,
+    Question,
+    OptionChoice,
+    QuizScope,
+)
+from app.db.session import get_db
+from app.services import course_service
+from app.services import lesson_service
+
+router = APIRouter(prefix="/api", tags=["Content"])
+
+
+# ---------------------------------------------------------------------------
+# Internal schemas (inline to avoid proliferating schema files)
+# ---------------------------------------------------------------------------
+
+from pydantic import BaseModel, Field
+from typing import Any, Dict, List, Optional
+
+
+class OptionOut(BaseModel):
+    id: str
+    label: str
+    is_correct: bool
+
+
+class QuestionOut(BaseModel):
+    id: str
+    prompt: str
+    order_index: int
+    options: List[OptionOut]
+
+
+class LessonQuizOut(BaseModel):
+    id: str
+    title: Optional[str]
+    passing_score: int
+    questions: List[QuestionOut]
+
+
+class LessonContentOut(BaseModel):
+    id: str
+    title: str
+    description: Optional[str] = None
+    content: str
+    status: Optional[str] = None
+    order_index: int
+    source_refs: List[str] = Field(default_factory=list)
+    quiz: Optional[LessonQuizOut] = None
+
+
+class PublishResult(BaseModel):
+    published_chapters: int
+    published_lessons: int
+    skipped_chapters: int
+
+
+class GenerateContentBody(BaseModel):
+    lesson_ids: Optional[List[str]] = Field(
+        default=None,
+        description="Specific lesson IDs to generate; defaults to all draft lessons",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _run_content_bg(course_id: str, run_id: str) -> None:
+    """Async background task (fallback when ARQ is unavailable)."""
+    from app.db.session import get_db_context
+
+    with get_db_context() as db:
+        await lesson_service.generate_course_content(
+            course_id=course_id, db=db, run_id=run_id
+        )
+
+
+def _quiz_for_lesson(lesson_id: str, db: Session) -> Optional[LessonQuizOut]:
+    quiz = db.query(Quiz).filter(
+        Quiz.lesson_id == lesson_id, Quiz.scope == QuizScope.LESSON
+    ).first()
+    if quiz is None:
+        return None
+
+    questions = (
+        db.query(Question)
+        .filter(Question.quiz_id == quiz.id)
+        .order_by(Question.order_index)
+        .all()
+    )
+    q_out = []
+    for q in questions:
+        opts = (
+            db.query(OptionChoice)
+            .filter(OptionChoice.question_id == q.id)
+            .all()
+        )
+        q_out.append(
+            QuestionOut(
+                id=q.id,
+                prompt=q.prompt,
+                order_index=q.order_index,
+                options=[
+                    OptionOut(id=o.id, label=o.label, is_correct=o.is_correct)
+                    for o in opts
+                ],
+            )
+        )
+    return LessonQuizOut(
+        id=quiz.id,
+        title=quiz.title,
+        passing_score=quiz.passing_score,
+        questions=q_out,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /courses/{course_id}/content/generate
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/courses/{course_id}/content/generate",
+    status_code=202,
+    summary="Start lesson content generation for all draft lessons in a course",
+)
+async def generate_content(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    body: GenerateContentBody,
+    course_id: str = Path(..., min_length=1, max_length=36),
+    db: Session = Depends(get_db),
+):
+    course = course_service.get_course(db, course_id)
+    if course is None:
+        raise NotFoundError("Course", course_id)
+
+    # Verify there are draft lessons to process
+    draft_count = (
+        db.query(Lesson)
+        .join(Chapter, Lesson.chapter_id == Chapter.id)
+        .filter(Chapter.course_id == course_id, Chapter.status == "draft")
+        .count()
+    )
+    if draft_count == 0:
+        raise ValidationError_("No draft lessons found. Generate an outline first.")
+
+    run = GenerationRun(
+        id=str(uuid.uuid4()),
+        course_id=course_id,
+        doc_ids_json=json.dumps([]),
+        status=GenerationRunStatus.QUEUED,
+        prompt_version=lesson_service.CONTENT_PROMPT_VERSION,
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+
+    arq_pool = getattr(request.app.state, "arq_pool", None)
+    if arq_pool is not None:
+        await arq_pool.enqueue_job(
+            "generate_course_content",
+            course_id=course_id,
+            run_id=run.id,
+        )
+    else:
+        background_tasks.add_task(_run_content_bg, course_id, run.id)
+
+    return {"run_id": run.id, "status": run.status, "draft_lessons": draft_count}
+
+
+# ---------------------------------------------------------------------------
+# POST /courses/{course_id}/publish
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/courses/{course_id}/publish",
+    response_model=PublishResult,
+    summary="Publish all chapters/lessons that passed groundedness check",
+)
+def publish_course(
+    course_id: str = Path(..., min_length=1, max_length=36),
+    db: Session = Depends(get_db),
+):
+    course = course_service.get_course(db, course_id)
+    if course is None:
+        raise NotFoundError("Course", course_id)
+
+    result = lesson_service.publish_course(course_id, db)
+    return PublishResult(**result)
+
+
+# ---------------------------------------------------------------------------
+# GET /lessons/{lesson_id}/content
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/lessons/{lesson_id}/content",
+    response_model=LessonContentOut,
+    summary="Get lesson content, metadata, and associated quiz",
+)
+def get_lesson_content(
+    lesson_id: str = Path(..., min_length=1, max_length=36),
+    db: Session = Depends(get_db),
+):
+    lesson = db.query(Lesson).filter(Lesson.id == lesson_id).first()
+    if lesson is None:
+        raise NotFoundError("Lesson", lesson_id)
+
+    source_refs: List[str] = []
+    if lesson.source_refs_json:
+        try:
+            source_refs = json.loads(lesson.source_refs_json)
+        except json.JSONDecodeError:
+            pass
+
+    return LessonContentOut(
+        id=lesson.id,
+        title=lesson.title,
+        description=lesson.description,
+        content=lesson.content or "",
+        status=lesson.status,
+        order_index=lesson.order_index,
+        source_refs=source_refs,
+        quiz=_quiz_for_lesson(lesson.id, db),
+    )

--- a/services/ai/app/api/documents_api.py
+++ b/services/ai/app/api/documents_api.py
@@ -15,6 +15,7 @@ from app.schemas.document_schemas import (
     DocumentListItem,
     DocumentPreview,
     DocumentStatusResponse,
+    DocumentStructure,
 )
 from app.core.errors import NotFoundError
 from app.core.rate_limit import limiter
@@ -249,6 +250,21 @@ def get_document_preview(
     if preview is None:
         raise NotFoundError(resource="Document", identifier=document_id)
     return preview
+
+
+@router.get(
+    "/documents/{document_id}/structure",
+    response_model=DocumentStructure,
+    summary="Heading tree with page spans and parent-chunk anchors",
+)
+def get_document_structure(
+    document_id: str = PathParam(..., description="Document ID"),
+    db: Session = Depends(get_db),
+):
+    result = document_service.get_section_tree(db, document_id)
+    if result is None:
+        raise NotFoundError(resource="Document", identifier=document_id)
+    return DocumentStructure(document_id=document_id, **result)
 
 
 @router.delete(

--- a/services/ai/app/api/outline_api.py
+++ b/services/ai/app/api/outline_api.py
@@ -1,0 +1,283 @@
+"""Outline API — course builder phase 2.
+
+Endpoints:
+  POST   /courses/{id}/outline/generate   → enqueue map-reduce job, return run_id
+  GET    /courses/{id}/outline            → draft chapters/lessons
+  PATCH  /courses/{id}/outline            → rename / reorder / delete draft items
+  GET    /generation-runs/{run_id}        → job status + stage
+"""
+import json
+import uuid
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Path, Request, status
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
+from app.core.errors import NotFoundError, ValidationError_
+from app.db.models import (
+    Chapter,
+    DocumentStatus,
+    GenerationRun,
+    GenerationRunStatus,
+    Lesson,
+)
+from app.db.session import get_db
+from app.schemas.outline_schemas import (
+    ChapterDraftSchema,
+    GenerateOutlineBody,
+    GenerationRunSchema,
+    LessonDraftSchema,
+    OutlineResponse,
+    PatchOutlineBody,
+)
+from app.services import course_service
+
+router = APIRouter(prefix="/api", tags=["Outline"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _chapter_to_schema(chapter: Chapter) -> ChapterDraftSchema:
+    lessons = [
+        LessonDraftSchema(
+            id=ls.id,
+            title=ls.title,
+            description=ls.description,
+            status=ls.status,
+            order_index=ls.order_index,
+            source_refs=json.loads(ls.source_refs_json) if ls.source_refs_json else [],
+        )
+        for ls in sorted(chapter.lessons, key=lambda x: x.order_index)
+    ]
+    return ChapterDraftSchema(
+        id=chapter.id,
+        title=chapter.title,
+        description=chapter.description,
+        status=chapter.status,
+        order_index=chapter.order_index,
+        lessons=lessons,
+    )
+
+
+def _latest_run_id(course_id: str, db: Session) -> str | None:
+    run = (
+        db.query(GenerationRun)
+        .filter(GenerationRun.course_id == course_id)
+        .order_by(GenerationRun.created_at.desc())
+        .first()
+    )
+    return run.id if run else None
+
+
+async def _run_outline_bg(course_id: str, doc_ids: list, run_id: str) -> None:
+    """Async background task (fallback when ARQ is unavailable)."""
+    from app.db.session import get_db_context
+    from app.services import outline_service
+
+    with get_db_context() as db:
+        await outline_service.generate_outline(
+            course_id=course_id,
+            doc_ids=doc_ids,
+            db=db,
+            run_id=run_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# POST /courses/{course_id}/outline/generate
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/courses/{course_id}/outline/generate",
+    status_code=202,
+    summary="Start outline generation job (map-reduce over document sections)",
+)
+async def generate_outline(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    body: GenerateOutlineBody,
+    course_id: str = Path(..., min_length=1, max_length=36),
+    db: Session = Depends(get_db),
+):
+    course = course_service.get_course(db, course_id)
+    if course is None:
+        raise NotFoundError("Course", course_id)
+
+    # Resolve doc_ids: explicit list or all READY docs in the course
+    if body.doc_ids:
+        doc_ids = body.doc_ids
+    else:
+        from app.services.document_service import list_documents
+        doc_ids = [
+            d.id
+            for d in list_documents(db, course_id)
+            if d.status == DocumentStatus.READY
+        ]
+
+    if not doc_ids:
+        raise ValidationError_(
+            "No READY documents found. Upload and process at least one document first."
+        )
+
+    run = GenerationRun(
+        id=str(uuid.uuid4()),
+        course_id=course_id,
+        doc_ids_json=json.dumps(doc_ids),
+        status=GenerationRunStatus.QUEUED,
+        prompt_version="v1",
+        options_json=json.dumps(body.options) if body.options else None,
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+
+    arq_pool = getattr(request.app.state, "arq_pool", None)
+    if arq_pool is not None:
+        await arq_pool.enqueue_job(
+            "generate_course_outline",
+            course_id=course_id,
+            doc_ids=doc_ids,
+            run_id=run.id,
+        )
+    else:
+        background_tasks.add_task(_run_outline_bg, course_id, doc_ids, run.id)
+
+    return {"run_id": run.id, "status": run.status}
+
+
+# ---------------------------------------------------------------------------
+# GET /courses/{course_id}/outline
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/courses/{course_id}/outline",
+    response_model=OutlineResponse,
+    summary="Get the draft course outline (chapters + lessons)",
+)
+def get_outline(
+    course_id: str = Path(..., min_length=1, max_length=36),
+    db: Session = Depends(get_db),
+):
+    course = course_service.get_course(db, course_id)
+    if course is None:
+        raise NotFoundError("Course", course_id)
+
+    chapters = (
+        db.query(Chapter)
+        .filter(Chapter.course_id == course_id, Chapter.status == "draft")
+        .order_by(Chapter.order_index)
+        .all()
+    )
+
+    return OutlineResponse(
+        course_id=course_id,
+        run_id=_latest_run_id(course_id, db),
+        chapters=[_chapter_to_schema(ch) for ch in chapters],
+    )
+
+
+# ---------------------------------------------------------------------------
+# PATCH /courses/{course_id}/outline
+# ---------------------------------------------------------------------------
+
+@router.patch(
+    "/courses/{course_id}/outline",
+    response_model=OutlineResponse,
+    summary="Update draft outline: rename, reorder, or delete draft chapters/lessons",
+)
+def patch_outline(
+    body: PatchOutlineBody,
+    course_id: str = Path(..., min_length=1, max_length=36),
+    db: Session = Depends(get_db),
+):
+    course = course_service.get_course(db, course_id)
+    if course is None:
+        raise NotFoundError("Course", course_id)
+
+    for ch_patch in body.chapters:
+        chapter = (
+            db.query(Chapter)
+            .filter(Chapter.id == ch_patch.id, Chapter.course_id == course_id)
+            .first()
+        )
+        if chapter is None:
+            continue
+
+        if ch_patch.delete:
+            for ls in db.query(Lesson).filter(Lesson.chapter_id == chapter.id).all():
+                db.delete(ls)
+            db.delete(chapter)
+            db.flush()
+            continue
+
+        if ch_patch.title is not None:
+            chapter.title = ch_patch.title
+        if ch_patch.description is not None:
+            chapter.description = ch_patch.description
+        if ch_patch.order_index is not None:
+            chapter.order_index = ch_patch.order_index
+
+        for ls_patch in ch_patch.lessons:
+            lesson = (
+                db.query(Lesson)
+                .filter(Lesson.id == ls_patch.id, Lesson.chapter_id == chapter.id)
+                .first()
+            )
+            if lesson is None:
+                continue
+            if ls_patch.delete:
+                db.delete(lesson)
+                db.flush()
+                continue
+            if ls_patch.title is not None:
+                lesson.title = ls_patch.title
+            if ls_patch.description is not None:
+                lesson.description = ls_patch.description
+            if ls_patch.order_index is not None:
+                lesson.order_index = ls_patch.order_index
+
+    db.commit()
+
+    # Return updated outline
+    chapters = (
+        db.query(Chapter)
+        .filter(Chapter.course_id == course_id, Chapter.status == "draft")
+        .order_by(Chapter.order_index)
+        .all()
+    )
+    return OutlineResponse(
+        course_id=course_id,
+        run_id=_latest_run_id(course_id, db),
+        chapters=[_chapter_to_schema(ch) for ch in chapters],
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /generation-runs/{run_id}
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/generation-runs/{run_id}",
+    response_model=GenerationRunSchema,
+    summary="Poll a generation run for status and stage progress",
+)
+def get_generation_run(
+    run_id: str = Path(..., min_length=1, max_length=36),
+    db: Session = Depends(get_db),
+):
+    run = db.query(GenerationRun).filter(GenerationRun.id == run_id).first()
+    if run is None:
+        raise NotFoundError("GenerationRun", run_id)
+    return GenerationRunSchema(
+        id=run.id,
+        course_id=run.course_id,
+        status=run.status,
+        stage=run.stage,
+        error_message=run.error_message,
+        prompt_version=run.prompt_version,
+        started_at=run.started_at,
+        finished_at=run.finished_at,
+        created_at=run.created_at,
+    )

--- a/services/ai/app/api/study_api.py
+++ b/services/ai/app/api/study_api.py
@@ -1,7 +1,10 @@
 """Study API — action-aware RAG endpoints."""
+import asyncio
+import json
 from typing import List
 
 from fastapi import APIRouter, Depends, Path, Request
+from fastapi.responses import StreamingResponse
 
 from app.core.rate_limit import limiter
 from app.middleware.auth import CurrentUser, get_current_user
@@ -17,6 +20,10 @@ from app.services import study_service
 
 router = APIRouter(prefix="/api", tags=["Study"])
 
+# Keepalive interval for SSE streams: emit a comment line if no token arrives within
+# this many seconds. Prevents nginx/CloudFlare from closing idle connections (default 60 s).
+_SSE_KEEPALIVE_INTERVAL = 15.0
+
 
 @router.post(
     "/courses/{course_id}/study",
@@ -24,7 +31,7 @@ router = APIRouter(prefix="/api", tags=["Study"])
     summary="Run a study action on course material",
     description=(
         "Retrieves relevant passages and applies the requested study action "
-        "(explain, summarize, retrieve, open_questions, quiz, oral). "
+        "(explain, summarize, retrieve, open_questions, quiz, oral, derive, compare). "
         "Falls back gracefully when the QVAC service or LLM is unavailable."
     ),
 )
@@ -58,6 +65,70 @@ async def study(
         retrieval_used=result.retrieval_used,
         action=body.action.value,
     )
+
+
+@router.post(
+    "/courses/{course_id}/study/stream",
+    summary="Stream a study action on course material (SSE)",
+    description=(
+        "Same as POST /study but returns a Server-Sent Events stream.\n"
+        "Tokens are emitted as 'data: <json-string>\\n\\n'.\n"
+        "After the last token, a citations sentinel is emitted:\n"
+        "  'data: \"\\x00CITATIONS\\x00<json-array>\"\\n\\n'\n"
+        "followed by 'data: [DONE]\\n\\n'.\n"
+        "SSE comment lines (': keepalive') are sent every 15 s during retrieval to\n"
+        "prevent proxy timeouts. QUIZ and ORAL are buffered internally."
+    ),
+)
+@limiter.limit("20/minute")
+async def study_stream(
+    request: Request,
+    body: StudyDispatchRequest,
+    course_id: str = Path(..., description="Course whose documents to search"),
+    _current_user: CurrentUser = Depends(get_current_user),
+) -> StreamingResponse:
+    async def _event_generator():
+        # Drive the async generator manually so we can interleave keepalive comments
+        # when no token arrives within _SSE_KEEPALIVE_INTERVAL seconds.
+        # This prevents nginx/CloudFlare from closing the connection during the
+        # retrieval phase (which can take 20-40 s on limited hardware).
+        gen = study_service.stream_dispatch(
+            question=body.query,
+            course_id=course_id,
+            action=body.action,
+            rag_only=body.rag_only,
+        )
+        try:
+            while True:
+                try:
+                    chunk = await asyncio.wait_for(
+                        gen.__anext__(), timeout=_SSE_KEEPALIVE_INTERVAL
+                    )
+                    yield f"data: {_sse_encode(chunk)}\n\n"
+                except asyncio.TimeoutError:
+                    # No token yet — send SSE comment to keep TCP connection alive.
+                    # Browsers and SSE clients silently ignore comment lines.
+                    yield ": keepalive\n\n"
+                except StopAsyncIteration:
+                    break
+        except Exception as exc:
+            yield f"data: {_sse_encode('[ERROR] ' + str(exc))}\n\n"
+        finally:
+            await gen.aclose()
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(
+        _event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",   # disable nginx proxy buffering
+        },
+    )
+
+
+def _sse_encode(value: str) -> str:
+    return json.dumps(value)
 
 
 @router.get(

--- a/services/ai/app/core/rate_limit.py
+++ b/services/ai/app/core/rate_limit.py
@@ -2,8 +2,39 @@
 
 Import from here to ensure a single Limiter is used across the application.
 Avoids creating multiple independent rate limit counters.
+
+Key function: uses the authenticated user's sub/user_id claim when a valid
+Bearer token is present, so each user has an independent quota regardless of
+shared IPs (classrooms, VPNs, NAT). Falls back to remote IP for unauthenticated
+requests.  The JWT is decoded without signature verification here because the
+auth middleware has already validated it upstream; we only need the subject claim
+as a stable bucket key.
 """
+import logging
+
+import jwt
+from fastapi import Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-limiter = Limiter(key_func=get_remote_address)
+logger = logging.getLogger(__name__)
+
+
+def _get_user_or_ip(request: Request) -> str:
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        try:
+            payload = jwt.decode(
+                auth[7:],
+                options={"verify_signature": False},
+                algorithms=["HS256"],
+            )
+            uid = payload.get("sub") or payload.get("user_id")
+            if uid:
+                return f"user:{uid}"
+        except Exception:
+            pass
+    return get_remote_address(request)
+
+
+limiter = Limiter(key_func=_get_user_or_ip)

--- a/services/ai/app/db/models.py
+++ b/services/ai/app/db/models.py
@@ -169,6 +169,7 @@ class Lesson(Base):
     order_index: Mapped[int] = mapped_column(Integer, default=0)
     status: Mapped[Optional[str]] = mapped_column(String, default="published")
     source_refs_json: Mapped[Optional[str]] = mapped_column(Text)
+    content_hash: Mapped[Optional[str]] = mapped_column(String)
 
     chapter: Mapped["Chapter"] = relationship(back_populates="lessons")
     quizzes: Mapped[List["Quiz"]] = relationship(back_populates="lesson")

--- a/services/ai/app/db/models.py
+++ b/services/ai/app/db/models.py
@@ -60,6 +60,13 @@ class DocumentStatus(str, Enum):
     ERROR = "error"
 
 
+class GenerationRunStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    DONE = "done"
+    ERROR = "error"
+
+
 # 1. Users
 class User(Base):
     __tablename__ = "app_user"
@@ -138,6 +145,7 @@ class Chapter(Base):
     title: Mapped[str] = mapped_column(String)
     description: Mapped[Optional[str]] = mapped_column(Text)
     order_index: Mapped[int] = mapped_column(Integer, default=0)
+    status: Mapped[Optional[str]] = mapped_column(String, default="published")
 
     course: Mapped["Course"] = relationship(back_populates="chapters")
     lessons: Mapped[List["Lesson"]] = relationship(back_populates="chapter")
@@ -159,6 +167,8 @@ class Lesson(Base):
     description: Mapped[Optional[str]] = mapped_column(Text)
     content: Mapped[str] = mapped_column(Text)
     order_index: Mapped[int] = mapped_column(Integer, default=0)
+    status: Mapped[Optional[str]] = mapped_column(String, default="published")
+    source_refs_json: Mapped[Optional[str]] = mapped_column(Text)
 
     chapter: Mapped["Chapter"] = relationship(back_populates="lessons")
     quizzes: Mapped[List["Quiz"]] = relationship(back_populates="lesson")
@@ -358,6 +368,9 @@ class CourseDocument(Base):
     metadata_json: Mapped[Optional[str]] = mapped_column(Text)
     extracted_text_preview: Mapped[Optional[str]] = mapped_column(Text)
     sections_json: Mapped[Optional[str]] = mapped_column(Text)
+    # Nested heading tree with page spans and parent-chunk anchors
+    # (course builder outline source). See pipeline.build_section_tree().
+    section_tree_json: Mapped[Optional[str]] = mapped_column(Text)
     sample_chunks_json: Mapped[Optional[str]] = mapped_column(Text)
 
     created_at: Mapped[datetime] = mapped_column(String, default=func.now())
@@ -368,7 +381,30 @@ class CourseDocument(Base):
     course: Mapped["Course"] = relationship(back_populates="documents")
 
 
-# 6. Supplemental Materials
+# 6. Course Builder — generation provenance
+class GenerationRun(Base):
+    """Provenance record for each outline or content generation job."""
+
+    __tablename__ = "generation_run"
+
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    course_id: Mapped[str] = mapped_column(ForeignKey("course.id"))
+    doc_ids_json: Mapped[str] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(String, default=GenerationRunStatus.QUEUED)
+    stage: Mapped[Optional[str]] = mapped_column(String)
+    error_message: Mapped[Optional[str]] = mapped_column(Text)
+    prompt_version: Mapped[Optional[str]] = mapped_column(String)
+    started_at: Mapped[Optional[str]] = mapped_column(String)
+    finished_at: Mapped[Optional[str]] = mapped_column(String)
+    options_json: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(String, default=func.now())
+
+    course: Mapped["Course"] = relationship()
+
+
+# 8. Supplemental Materials
 class Resource(Base):
     __tablename__ = "resource"
 
@@ -392,7 +428,7 @@ class Resource(Base):
         back_populates="created_resources")
 
 
-# 6. Badges
+# 9. Badges
 class Badge(Base):
     """Badge definition — one row per badge type."""
 
@@ -427,7 +463,7 @@ class UserBadge(Base):
     badge: Mapped["Badge"] = relationship(back_populates="awards")
 
 
-# 7. RAG parent chunks (parent-child chunking — Sprint 2)
+# 10. RAG parent chunks (parent-child chunking — Sprint 2)
 class ChunkParent(Base):
     """Parent chunk: 1200-word context block used by the LLM after child retrieval."""
 
@@ -442,7 +478,7 @@ class ChunkParent(Base):
     citation_section: Mapped[str] = mapped_column(String, default="")
 
 
-# 8. Answer Feedback (Q8 — student thumbs up/down on RAG answers)
+# 11. Answer Feedback (Q8 — student thumbs up/down on RAG answers)
 class AnswerFeedback(Base):
     """Student rating of a RAG-generated answer (thumbs up/down + optional comment)."""
 
@@ -460,7 +496,7 @@ class AnswerFeedback(Base):
     created_at: Mapped[datetime] = mapped_column(String, default=func.now())
 
 
-# 9. Certificates
+# 12. Certificates
 class Certificate(Base):
     __tablename__ = "certificate"
 

--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -16,6 +16,7 @@ from app.api.courses_api import router as courses_router
 from app.api.documents_api import router as documents_router
 from app.api.feedback_api import router as feedback_router
 from app.api.progress_api import router as progress_router
+from app.api.outline_api import router as outline_router
 from app.api.quizzes_api import router as quizzes_router
 from app.api.study_api import router as study_router
 from app.db.session import init_db, get_db
@@ -149,6 +150,7 @@ app.include_router(courses_router)
 app.include_router(documents_router)
 app.include_router(feedback_router)
 app.include_router(progress_router)
+app.include_router(outline_router)
 app.include_router(quizzes_router)
 app.include_router(study_router)
 

--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -16,6 +16,7 @@ from app.api.courses_api import router as courses_router
 from app.api.documents_api import router as documents_router
 from app.api.feedback_api import router as feedback_router
 from app.api.progress_api import router as progress_router
+from app.api.content_api import router as content_router
 from app.api.outline_api import router as outline_router
 from app.api.quizzes_api import router as quizzes_router
 from app.api.study_api import router as study_router
@@ -150,6 +151,7 @@ app.include_router(courses_router)
 app.include_router(documents_router)
 app.include_router(feedback_router)
 app.include_router(progress_router)
+app.include_router(content_router)
 app.include_router(outline_router)
 app.include_router(quizzes_router)
 app.include_router(study_router)

--- a/services/ai/app/schemas/document_schemas.py
+++ b/services/ai/app/schemas/document_schemas.py
@@ -60,3 +60,22 @@ class DocumentPreview(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class SectionNode(BaseModel):
+    """One heading in the document's section tree (course builder source)."""
+    title: str
+    level: int
+    page_start: int
+    page_end: int
+    parent_chunk_ids: List[str]
+    children: List["SectionNode"] = []
+
+
+class DocumentStructure(BaseModel):
+    document_id: str
+    # "ingest" = heading hierarchy extracted at ingest;
+    # "rebuilt" = flat tree reconstructed from chunk_parent (legacy docs);
+    # "unavailable" = document not READY or no parents indexed.
+    source: str
+    tree: Optional[List[SectionNode]] = None

--- a/services/ai/app/schemas/outline_schemas.py
+++ b/services/ai/app/schemas/outline_schemas.py
@@ -1,0 +1,85 @@
+"""Pydantic schemas for outline generation endpoints."""
+import json
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class GenerationRunSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    course_id: str
+    status: str
+    stage: Optional[str] = None
+    error_message: Optional[str] = None
+    prompt_version: Optional[str] = None
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    created_at: str
+
+    @property
+    def doc_ids(self) -> List[str]:
+        try:
+            return json.loads(self.doc_ids_json) if hasattr(self, "doc_ids_json") else []
+        except (json.JSONDecodeError, AttributeError):
+            return []
+
+
+class LessonDraftSchema(BaseModel):
+    id: str
+    title: str
+    description: Optional[str] = None
+    status: Optional[str] = None
+    order_index: int
+    source_refs: List[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=False)
+
+
+class ChapterDraftSchema(BaseModel):
+    id: str
+    title: str
+    description: Optional[str] = None
+    status: Optional[str] = None
+    order_index: int
+    lessons: List[LessonDraftSchema] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=False)
+
+
+class OutlineResponse(BaseModel):
+    course_id: str
+    run_id: Optional[str] = None
+    chapters: List[ChapterDraftSchema] = Field(default_factory=list)
+
+
+# ---- Request bodies ----
+
+class GenerateOutlineBody(BaseModel):
+    doc_ids: Optional[List[str]] = Field(
+        default=None,
+        description="Document IDs to include; defaults to all READY docs in the course",
+    )
+    options: Optional[Dict[str, Any]] = Field(default=None)
+
+
+class LessonPatch(BaseModel):
+    id: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    order_index: Optional[int] = None
+    delete: bool = False
+
+
+class ChapterPatch(BaseModel):
+    id: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    order_index: Optional[int] = None
+    delete: bool = False
+    lessons: List[LessonPatch] = Field(default_factory=list)
+
+
+class PatchOutlineBody(BaseModel):
+    chapters: List[ChapterPatch] = Field(default_factory=list)

--- a/services/ai/app/services/document_service.py
+++ b/services/ai/app/services/document_service.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
-from app.db.models import CourseDocument, DocumentProcessingStage, DocumentStatus
+from app.db.models import ChunkParent, CourseDocument, DocumentProcessingStage, DocumentStatus
 from app.repositories import document_repo
 
 
@@ -87,3 +87,43 @@ def get_preview(db: Session, document_id: str) -> Optional[Dict[str, Any]]:
         "sections": sections,
         "sample_chunks": sample_chunks,
     }
+
+
+def get_section_tree(db: Session, document_id: str) -> Optional[Dict[str, Any]]:
+    """Return the document's heading tree, rebuilding it for legacy documents.
+
+    Documents ingested before the section-tree stage have no
+    section_tree_json and their source file may be gone (the pipeline
+    deletes it), so a full re-parse is impossible. In that case a flat
+    level-1 tree is rebuilt on the fly from the chunk_parent rows (which
+    preserve section title and page per parent) and returned with
+    source="rebuilt" — not persisted, so the flag stays honest.
+    Re-ingesting via POST /courses/{id}/reindex produces the full heading
+    hierarchy (source="ingest").
+    """
+    doc = document_repo.get_by_id(db, document_id)
+    if doc is None:
+        return None
+
+    if doc.section_tree_json:
+        try:
+            return {"tree": json.loads(doc.section_tree_json), "source": "ingest"}
+        except json.JSONDecodeError:
+            pass  # corrupt blob — fall through to rebuild
+
+    if doc.status != DocumentStatus.READY:
+        return {"tree": None, "source": "unavailable"}
+
+    from app.workers.pipeline import build_section_events_from_parents, build_section_tree
+
+    parent_rows = (
+        db.query(ChunkParent)
+        .filter(ChunkParent.doc_id == document_id)
+        .order_by(ChunkParent.id)
+        .all()
+    )
+    if not parent_rows:
+        return {"tree": None, "source": "unavailable"}
+
+    tree = build_section_tree(build_section_events_from_parents(parent_rows))
+    return {"tree": tree, "source": "rebuilt"}

--- a/services/ai/app/services/lesson_service.py
+++ b/services/ai/app/services/lesson_service.py
@@ -1,0 +1,588 @@
+"""Lesson content generation service — Phase 3 of the course builder.
+
+For each draft lesson:
+  1. Load the source parent chunks anchored in lesson.source_refs_json.
+  2. Call /generate_json to produce Markdown content + objectives + glossary + self_check.
+  3. Run a groundedness judge (second LLM pass) that reads the content and sources,
+     returning {faithful: bool, issues: [str]}.
+  4. Persist content into Lesson.content; set status "published" or "needs_review".
+  5. Generate a lesson quiz (3-4 MCQ) and persist to Quiz/Question/OptionChoice tables.
+
+Caching: content_hash = SHA256(sorted source_refs + lesson.title + CONTENT_PROMPT_VERSION).
+If the hash matches the stored one and content is non-empty, the lesson is skipped.
+
+All LLM calls go through qvac_structured.generate_json.
+"""
+import hashlib
+import json
+import logging
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    Chapter,
+    ChunkParent,
+    GenerationRun,
+    GenerationRunStatus,
+    Lesson,
+    OptionChoice,
+    Question,
+    QuestionType,
+    Quiz,
+    QuizScope,
+)
+from app.services.qvac_structured import (
+    LlmDisabledError,
+    StructuredGenerationError,
+    generate_json,
+)
+
+logger = logging.getLogger(__name__)
+
+CONTENT_PROMPT_VERSION = "v1"
+
+# Max parent chunks to include in the generation context (token-budget guard).
+MAX_CONTEXT_CHUNKS = 3
+
+# ---------------------------------------------------------------------------
+# JSON schemas
+# ---------------------------------------------------------------------------
+
+_CONTENT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required": ["content", "objectives", "glossary", "self_check"],
+    "properties": {
+        "content": {"type": "string"},
+        "objectives": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "maxItems": 4,
+        },
+        "glossary": {
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 8,
+            "items": {
+                "type": "object",
+                "required": ["term", "definition"],
+                "properties": {
+                    "term": {"type": "string"},
+                    "definition": {"type": "string"},
+                },
+            },
+        },
+        "self_check": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 2,
+            "maxItems": 3,
+        },
+    },
+}
+
+_JUDGE_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required": ["faithful", "issues"],
+    "properties": {
+        "faithful": {"type": "boolean"},
+        "issues": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 0,
+            "maxItems": 5,
+        },
+    },
+}
+
+_QUIZ_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required": ["questions"],
+    "properties": {
+        "questions": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 4,
+            "items": {
+                "type": "object",
+                "required": ["prompt", "options", "correct_key"],
+                "properties": {
+                    "prompt": {"type": "string"},
+                    "options": {
+                        "type": "array",
+                        "minItems": 4,
+                        "maxItems": 4,
+                        "items": {
+                            "type": "object",
+                            "required": ["key", "text"],
+                            "properties": {
+                                "key": {
+                                    "type": "string",
+                                    "enum": ["A", "B", "C", "D"],
+                                },
+                                "text": {"type": "string"},
+                            },
+                        },
+                    },
+                    "correct_key": {
+                        "type": "string",
+                        "enum": ["A", "B", "C", "D"],
+                    },
+                },
+            },
+        }
+    },
+}
+
+# ---------------------------------------------------------------------------
+# System prompts
+# ---------------------------------------------------------------------------
+
+_CONTENT_SYSTEM = (
+    "You are an expert course author at BitPolito Academy. "
+    "Write a complete, pedagogically structured lesson from the provided source material.\n"
+    "RULES:\n"
+    "1. Use ONLY the information in the provided source passages — never inject external knowledge.\n"
+    "2. Use exact technical terminology from the document (UTXO, hashrate, proof-of-work, etc.).\n"
+    "3. Cite every factual claim as [ref_N] where N is the 1-based passage index.\n"
+    "4. Write 3–5 focused paragraphs: introduction → key concepts → synthesis.\n"
+    "5. Do NOT open with generic phrases like 'In this lesson' or 'Based on the context'.\n"
+    "6. Objectives: 2–4 specific, measurable learning outcomes (verb + concept).\n"
+    "7. Glossary: include only technical terms that appear in the source.\n"
+    "8. Self-check: 2–3 concise questions a student should answer after reading."
+)
+
+_JUDGE_SYSTEM = (
+    "You are a groundedness judge for educational content. "
+    "Your task is to verify that the lesson content is faithful to the provided source passages.\n"
+    "RULES:\n"
+    "1. Check whether claims marked [ref_N] are actually supported by the corresponding passage.\n"
+    "2. Flag claims that contradict the source, exaggerate, or introduce information not in the text.\n"
+    "3. Minor rephrasing of source text is acceptable if meaning is preserved.\n"
+    "4. Return faithful=true only if ALL cited claims are directly supported."
+)
+
+_QUIZ_SYSTEM = (
+    "You are an expert educator at BitPolito Academy creating assessment questions.\n"
+    "RULES:\n"
+    "1. Create 3–4 multiple-choice questions based ONLY on the provided source passages.\n"
+    "2. Each question tests conceptual understanding, not trivial recall.\n"
+    "3. All 4 options (A–D) must be plausible — wrong options should be conceptually close.\n"
+    "4. The correct answer must be directly supported by the source text.\n"
+    "5. Use exact technical terminology from the document."
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _compute_hash(lesson: Lesson) -> str:
+    """SHA256 of (sorted source_refs + lesson.title + prompt_version)."""
+    refs: List[str] = []
+    if lesson.source_refs_json:
+        try:
+            refs = json.loads(lesson.source_refs_json)
+        except json.JSONDecodeError:
+            pass
+    payload = json.dumps(sorted(refs)) + lesson.title + CONTENT_PROMPT_VERSION
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _load_context(lesson: Lesson, db: Session) -> Tuple[List[str], List[Dict[str, str]]]:
+    """Return (source_ref_ids, context_items) for the lesson.
+
+    Context items follow the /generate convention: {"label": str, "text": str}.
+    Capped at MAX_CONTEXT_CHUNKS to stay within the 8K token budget.
+    """
+    if not lesson.source_refs_json:
+        return [], []
+    try:
+        chunk_ids: List[str] = json.loads(lesson.source_refs_json)
+    except json.JSONDecodeError:
+        return [], []
+
+    chunk_ids = chunk_ids[:MAX_CONTEXT_CHUNKS]
+    rows = {
+        r.id: r
+        for r in db.query(ChunkParent).filter(ChunkParent.id.in_(chunk_ids)).all()
+    }
+    context_items: List[Dict[str, str]] = []
+    used_ids: List[str] = []
+    for cid in chunk_ids:
+        if cid in rows:
+            context_items.append({"label": cid, "text": rows[cid].text})
+            used_ids.append(cid)
+    return used_ids, context_items
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _update_run(run: GenerationRun, db: Session, status: str, stage: Optional[str] = None, error: Optional[str] = None) -> None:
+    run.status = status
+    if stage is not None:
+        run.stage = stage
+    if error is not None:
+        run.error_message = error
+    if status == GenerationRunStatus.RUNNING and run.started_at is None:
+        run.started_at = _now_iso()
+    if status in (GenerationRunStatus.DONE, GenerationRunStatus.ERROR):
+        run.finished_at = _now_iso()
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Content generation
+# ---------------------------------------------------------------------------
+
+async def _generate_content(
+    lesson: Lesson, context_items: List[Dict[str, str]]
+) -> Dict[str, Any]:
+    """Call /generate_json to produce lesson content + metadata."""
+    prompt = (
+        f'Write a complete lesson titled: "{lesson.title}".\n'
+        f"Description: {lesson.description or lesson.title}\n\n"
+        "Produce: lesson content (Markdown with [ref_N] citations), "
+        "learning objectives, glossary of key terms, and self-check questions."
+    )
+    return await generate_json(
+        prompt,
+        _CONTENT_SCHEMA,
+        context=context_items,
+        system_prompt=_CONTENT_SYSTEM,
+        generation_params={"temp": 0.2},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Groundedness judge
+# ---------------------------------------------------------------------------
+
+async def _judge_groundedness(
+    content: str, context_items: List[Dict[str, str]]
+) -> Dict[str, Any]:
+    """Check that the lesson content is faithful to its source passages."""
+    # Truncate content for judge to save tokens (first 800 words)
+    content_preview = " ".join(content.split()[:800])
+    prompt = (
+        "Review this lesson content for faithfulness to the provided source passages.\n\n"
+        f"LESSON CONTENT:\n{content_preview}\n\n"
+        "Check: are all [ref_N] claims directly supported by the corresponding passages? "
+        "List any unsupported or exaggerated claims as issues."
+    )
+    # Use abbreviated source for judge (first 200 words per chunk)
+    judge_context = [
+        {"label": item["label"], "text": " ".join(item["text"].split()[:200])}
+        for item in context_items
+    ]
+    return await generate_json(
+        prompt,
+        _JUDGE_SCHEMA,
+        context=judge_context,
+        system_prompt=_JUDGE_SYSTEM,
+        generation_params={"temp": 0.1},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quiz generation
+# ---------------------------------------------------------------------------
+
+async def _generate_quiz_data(
+    lesson: Lesson, context_items: List[Dict[str, str]]
+) -> Optional[Dict[str, Any]]:
+    """Call /generate_json to produce MCQ quiz data."""
+    prompt = (
+        f'Generate a quiz for the lesson "{lesson.title}". '
+        "Create 3-4 multiple-choice questions that test understanding of the key concepts "
+        "in the provided source passages."
+    )
+    try:
+        return await generate_json(
+            prompt,
+            _QUIZ_SCHEMA,
+            context=context_items,
+            system_prompt=_QUIZ_SYSTEM,
+            generation_params={"temp": 0.3},
+        )
+    except StructuredGenerationError as exc:
+        logger.warning("Quiz generation failed for lesson %s: %s", lesson.id, exc)
+        return None
+
+
+def _persist_quiz(lesson: Lesson, quiz_data: Dict[str, Any], db: Session) -> Optional[str]:
+    """Write Quiz / Question / OptionChoice rows linked to the lesson."""
+    raw_questions = quiz_data.get("questions", [])
+    if not raw_questions:
+        return None
+
+    # Remove any existing lesson quiz
+    existing = db.query(Quiz).filter(
+        Quiz.lesson_id == lesson.id, Quiz.scope == QuizScope.LESSON
+    ).first()
+    if existing:
+        for q in db.query(Question).filter(Question.quiz_id == existing.id).all():
+            db.query(OptionChoice).filter(OptionChoice.question_id == q.id).delete()
+            db.delete(q)
+        db.delete(existing)
+        db.flush()
+
+    quiz = Quiz(
+        id=str(uuid.uuid4()),
+        scope=QuizScope.LESSON,
+        title=f"Quiz: {lesson.title[:80]}",
+        passing_score=70,
+        lesson_id=lesson.id,
+    )
+    db.add(quiz)
+    db.flush()
+
+    for order_idx, q_data in enumerate(raw_questions):
+        question = Question(
+            id=str(uuid.uuid4()),
+            quiz_id=quiz.id,
+            qtype=QuestionType.MCQ,
+            prompt=q_data["prompt"],
+            order_index=order_idx,
+        )
+        db.add(question)
+        db.flush()
+
+        correct_key = q_data.get("correct_key", "A")
+        for opt in q_data.get("options", []):
+            choice = OptionChoice(
+                id=str(uuid.uuid4()),
+                question_id=question.id,
+                label=f"{opt['key']}) {opt['text']}",
+                is_correct=(opt["key"] == correct_key),
+            )
+            db.add(choice)
+
+    db.commit()
+    return quiz.id
+
+
+# ---------------------------------------------------------------------------
+# Single-lesson orchestrator
+# ---------------------------------------------------------------------------
+
+async def process_lesson(lesson_id: str, db: Session) -> str:
+    """Generate content, run groundedness judge, generate quiz for one lesson.
+
+    Returns the final lesson status: "published", "needs_review", or "skipped".
+    The lesson is skipped if:
+      - it has no source refs (can't generate grounded content)
+      - its content_hash is unchanged (already generated from the same sources)
+    """
+    lesson = db.query(Lesson).filter(Lesson.id == lesson_id).first()
+    if lesson is None:
+        raise ValueError(f"Lesson {lesson_id} not found")
+
+    # ---- Cache check ----
+    current_hash = _compute_hash(lesson)
+    if lesson.content_hash == current_hash and lesson.content:
+        logger.info("lesson %s: cache hit — skipping", lesson_id)
+        return "skipped"
+
+    # ---- Load context ----
+    used_ids, context_items = _load_context(lesson, db)
+    if not context_items:
+        logger.warning("lesson %s: no source refs — marking needs_review", lesson_id)
+        lesson.status = "needs_review"
+        db.commit()
+        return "needs_review"
+
+    # ---- Content generation ----
+    try:
+        result = await _generate_content(lesson, context_items)
+    except LlmDisabledError:
+        raise
+    except StructuredGenerationError as exc:
+        logger.warning("lesson %s: content generation failed: %s", lesson_id, exc)
+        lesson.status = "needs_review"
+        db.commit()
+        return "needs_review"
+
+    content = result.get("content", "")
+    objectives = result.get("objectives", [])
+    glossary = result.get("glossary", [])
+    self_check = result.get("self_check", [])
+
+    if not content.strip():
+        lesson.status = "needs_review"
+        db.commit()
+        return "needs_review"
+
+    # ---- Groundedness judge ----
+    try:
+        verdict = await _judge_groundedness(content, context_items)
+        faithful = verdict.get("faithful", True)
+        issues = verdict.get("issues", [])
+    except (LlmDisabledError, StructuredGenerationError) as exc:
+        logger.warning(
+            "lesson %s: judge failed (%s) — assuming faithful", lesson_id, exc
+        )
+        faithful = True
+        issues = []
+
+    final_status = "published" if faithful else "needs_review"
+
+    # ---- Persist content ----
+    # Append objectives, glossary, self_check as Markdown sections after the main content.
+    full_content = content
+
+    if objectives:
+        obj_lines = "\n".join(f"- {o}" for o in objectives)
+        full_content += f"\n\n## Learning Objectives\n{obj_lines}"
+
+    if glossary:
+        gloss_lines = "\n".join(f"**{g['term']}**: {g['definition']}" for g in glossary)
+        full_content += f"\n\n## Glossary\n{gloss_lines}"
+
+    if self_check:
+        sc_lines = "\n".join(f"{i+1}. {q}" for i, q in enumerate(self_check))
+        full_content += f"\n\n## Self-Check\n{sc_lines}"
+
+    if issues:
+        issues_lines = "\n".join(f"- {iss}" for iss in issues)
+        full_content += f"\n\n<!-- groundedness_issues:\n{issues_lines}\n-->"
+
+    lesson.content = full_content
+    lesson.content_hash = current_hash
+    lesson.status = final_status
+    db.commit()
+
+    # ---- Quiz ----
+    try:
+        quiz_data = await _generate_quiz_data(lesson, context_items)
+        if quiz_data:
+            _persist_quiz(lesson, quiz_data, db)
+    except LlmDisabledError:
+        raise
+    except Exception as exc:
+        logger.warning("lesson %s: quiz generation failed: %s", lesson_id, exc)
+
+    logger.info(
+        "lesson %s (%s): status=%s faithful=%s",
+        lesson_id,
+        lesson.title[:40],
+        final_status,
+        faithful,
+    )
+    return final_status
+
+
+# ---------------------------------------------------------------------------
+# Course-level orchestrator
+# ---------------------------------------------------------------------------
+
+async def generate_course_content(
+    course_id: str,
+    db: Session,
+    run_id: str,
+) -> None:
+    """Process all draft lessons for a course sequentially.
+
+    Updates GenerationRun status/stage at each step for frontend polling.
+    """
+    run = db.query(GenerationRun).filter(GenerationRun.id == run_id).first()
+    if run is None:
+        raise ValueError(f"GenerationRun {run_id} not found")
+
+    _update_run(run, db, GenerationRunStatus.RUNNING, "init")
+
+    # Fetch all draft lessons for this course (via chapter join)
+    lessons = (
+        db.query(Lesson)
+        .join(Chapter, Lesson.chapter_id == Chapter.id)
+        .filter(Chapter.course_id == course_id, Chapter.status == "draft")
+        .order_by(Chapter.order_index, Lesson.order_index)
+        .all()
+    )
+
+    if not lessons:
+        _update_run(run, db, GenerationRunStatus.ERROR, error="No draft lessons found for this course")
+        return
+
+    total = len(lessons)
+    published = 0
+    needs_review = 0
+    skipped = 0
+
+    for idx, lesson in enumerate(lessons):
+        _update_run(run, db, GenerationRunStatus.RUNNING, f"lesson_{idx + 1}/{total}")
+        try:
+            result = await process_lesson(lesson.id, db)
+            if result == "published":
+                published += 1
+            elif result == "needs_review":
+                needs_review += 1
+            else:
+                skipped += 1
+        except LlmDisabledError as exc:
+            _update_run(run, db, GenerationRunStatus.ERROR, error=f"LLM disabled: {exc}")
+            return
+        except Exception as exc:
+            logger.exception("lesson %s: unexpected error", lesson.id)
+            _update_run(run, db, GenerationRunStatus.ERROR, error=str(exc))
+            return
+
+    _update_run(run, db, GenerationRunStatus.DONE, "done")
+    logger.info(
+        "content generation done: course=%s published=%d needs_review=%d skipped=%d",
+        course_id, published, needs_review, skipped,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Publication
+# ---------------------------------------------------------------------------
+
+def publish_course(course_id: str, db: Session) -> Dict[str, int]:
+    """Mark chapters and lessons as published.
+
+    Only chapters where every lesson is 'published' (not needs_review) are
+    published. Chapters with any needs_review lesson remain draft.
+
+    Returns counts: {published_chapters, published_lessons, skipped_chapters}.
+    """
+    chapters = (
+        db.query(Chapter)
+        .filter(Chapter.course_id == course_id, Chapter.status == "draft")
+        .all()
+    )
+
+    published_chapters = 0
+    published_lessons = 0
+    skipped_chapters = 0
+
+    for chapter in chapters:
+        lessons = db.query(Lesson).filter(Lesson.chapter_id == chapter.id).all()
+        if not lessons:
+            skipped_chapters += 1
+            continue
+
+        publishable = [ls for ls in lessons if ls.status == "published"]
+        blocking = [ls for ls in lessons if ls.status == "needs_review"]
+
+        if blocking:
+            skipped_chapters += 1
+            continue
+
+        if publishable:
+            for ls in publishable:
+                ls.status = "published"
+                published_lessons += 1
+            chapter.status = "published"
+            published_chapters += 1
+
+    db.commit()
+    return {
+        "published_chapters": published_chapters,
+        "published_lessons": published_lessons,
+        "skipped_chapters": skipped_chapters,
+    }

--- a/services/ai/app/services/outline_service.py
+++ b/services/ai/app/services/outline_service.py
@@ -1,0 +1,484 @@
+"""Outline generation service — Phase 2 of the course builder.
+
+Map-reduce pipeline:
+  map  : for each document, call /generate_json once per top-level section to
+         extract topic candidates grounded on real parent-chunk text.
+  reduce: single LLM call to group candidates into chapters, deduplicate across
+          documents, and order them pedagogically.
+  persist: write draft Chapter / Lesson rows + update GenerationRun provenance.
+
+All LLM calls go through qvac_structured.generate_json which enforces JSON
+schema server-side (extraction + validation + correction retries).
+"""
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.db.models import (
+    Chapter,
+    ChunkParent,
+    CourseDocument,
+    DocumentStatus,
+    GenerationRun,
+    GenerationRunStatus,
+    Lesson,
+)
+from app.services.qvac_structured import (
+    LlmDisabledError,
+    StructuredGenerationError,
+    generate_json,
+)
+
+logger = logging.getLogger(__name__)
+
+OUTLINE_PROMPT_VERSION = "v1"
+
+# How many top-level sections to map per document (token-budget guard).
+MAX_SECTIONS_PER_DOC = 20
+# Total words of parent-chunk preview sent as context for one section.
+MAX_WORDS_PER_SECTION = 800
+# Cap total candidates fed to the reduce step.
+MAX_CANDIDATES_TOTAL = 50
+
+
+# ---------------------------------------------------------------------------
+# JSON schemas for /generate_json calls
+# ---------------------------------------------------------------------------
+
+_MAP_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required": ["lessons"],
+    "properties": {
+        "lessons": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 3,
+            "items": {
+                "type": "object",
+                "required": ["title", "key_concepts", "difficulty"],
+                "properties": {
+                    "title": {"type": "string"},
+                    "key_concepts": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                        "maxItems": 6,
+                    },
+                    "difficulty": {
+                        "type": "string",
+                        "enum": ["beginner", "intermediate", "advanced"],
+                    },
+                },
+            },
+        }
+    },
+}
+
+_REDUCE_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "required": ["chapters"],
+    "properties": {
+        "chapters": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 12,
+            "items": {
+                "type": "object",
+                "required": ["title", "description", "lessons"],
+                "properties": {
+                    "title": {"type": "string"},
+                    "description": {"type": "string"},
+                    "lessons": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 8,
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "title",
+                                "description",
+                                "objectives",
+                                "candidate_indices",
+                            ],
+                            "properties": {
+                                "title": {"type": "string"},
+                                "description": {"type": "string"},
+                                "objectives": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "minItems": 1,
+                                    "maxItems": 4,
+                                },
+                                "candidate_indices": {
+                                    "type": "array",
+                                    "items": {"type": "integer"},
+                                    "minItems": 1,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    },
+}
+
+_MAP_SYSTEM = (
+    "You are an expert curriculum designer. "
+    "Given a document section and its source text, extract self-contained "
+    "lesson topics suitable for a structured course. "
+    "Stay strictly faithful to the source material — do not invent content."
+)
+
+_REDUCE_SYSTEM = (
+    "You are an expert curriculum designer. "
+    "Group the given lesson topics into a coherent, pedagogically ordered course. "
+    "Order chapters from foundational to advanced. "
+    "Merge near-duplicate topics that cover the same concept. "
+    "Reference every topic by its index — do not leave any topic unused."
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _collect_chunk_ids(section: Dict[str, Any], max_chunks: int = 8) -> List[str]:
+    """BFS over section tree, collecting parent_chunk_ids up to max_chunks."""
+    result: List[str] = []
+    queue = [section]
+    while queue and len(result) < max_chunks:
+        node = queue.pop(0)
+        for cid in node.get("parent_chunk_ids", []):
+            if len(result) >= max_chunks:
+                break
+            result.append(cid)
+        queue.extend(node.get("children", []))
+    return result
+
+
+def _section_context(
+    chunk_ids: List[str], db: Session
+) -> List[Dict[str, str]]:
+    """Fetch up to MAX_WORDS_PER_SECTION words of parent-chunk text as context items."""
+    if not chunk_ids:
+        return []
+    rows = {r.id: r for r in db.query(ChunkParent).filter(ChunkParent.id.in_(chunk_ids)).all()}
+    items: List[Dict[str, str]] = []
+    total_words = 0
+    for cid in chunk_ids:
+        if cid not in rows:
+            continue
+        words = rows[cid].text.split()
+        budget = MAX_WORDS_PER_SECTION - total_words
+        if budget <= 0:
+            break
+        snippet = " ".join(words[:budget])
+        items.append({"label": cid, "text": snippet})
+        total_words += min(len(words), budget)
+    return items
+
+
+def _get_section_tree(doc: CourseDocument, db: Session) -> Optional[List[Dict[str, Any]]]:
+    """Return the section tree for a document, rebuilding from parents if needed."""
+    if doc.section_tree_json:
+        try:
+            return json.loads(doc.section_tree_json)
+        except json.JSONDecodeError:
+            pass
+
+    if doc.status != DocumentStatus.READY:
+        return None
+
+    from app.workers.pipeline import build_section_events_from_parents, build_section_tree
+
+    parent_rows = (
+        db.query(ChunkParent)
+        .filter(ChunkParent.doc_id == doc.id)
+        .order_by(ChunkParent.id)
+        .all()
+    )
+    if not parent_rows:
+        return None
+    return build_section_tree(build_section_events_from_parents(parent_rows))
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _update_run(
+    run: GenerationRun,
+    db: Session,
+    status: str,
+    stage: Optional[str] = None,
+    error: Optional[str] = None,
+) -> None:
+    run.status = status
+    if stage is not None:
+        run.stage = stage
+    if error is not None:
+        run.error_message = error
+    if status == GenerationRunStatus.RUNNING and run.started_at is None:
+        run.started_at = _now_iso()
+    if status in (GenerationRunStatus.DONE, GenerationRunStatus.ERROR):
+        run.finished_at = _now_iso()
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Map step
+# ---------------------------------------------------------------------------
+
+async def _map_section(
+    section: Dict[str, Any], doc_id: str, db: Session
+) -> List[Dict[str, Any]]:
+    """Extract lesson candidates from one section via /generate_json."""
+    chunk_ids = _collect_chunk_ids(section)
+    context = _section_context(chunk_ids, db)
+    if not context:
+        return []
+
+    prompt = (
+        f'Section: "{section["title"]}" '
+        f'(pages {section.get("page_start", "?")}–{section.get("page_end", "?")})\n\n'
+        "Extract 1-3 self-contained lesson topics from this section. "
+        "Each lesson must be directly supported by the source text."
+    )
+
+    result = await generate_json(
+        prompt,
+        _MAP_SCHEMA,
+        context=context,
+        system_prompt=_MAP_SYSTEM,
+        generation_params={"temp": 0.15},
+    )
+
+    candidates = []
+    for ls in result.get("lessons", []):
+        candidates.append(
+            {
+                "title": ls["title"],
+                "key_concepts": ls.get("key_concepts", []),
+                "difficulty": ls.get("difficulty", "intermediate"),
+                "source_chunk_ids": chunk_ids,
+                "source_doc_id": doc_id,
+                "section_title": section["title"],
+            }
+        )
+    return candidates
+
+
+async def _map_document(
+    doc: CourseDocument, db: Session
+) -> List[Dict[str, Any]]:
+    """Run the map step for one document: iterate its top-level sections."""
+    tree = _get_section_tree(doc, db)
+    if not tree:
+        logger.warning("outline map: no section tree for document %s — skipping", doc.id)
+        return []
+
+    all_candidates: List[Dict[str, Any]] = []
+    for section in tree[:MAX_SECTIONS_PER_DOC]:
+        try:
+            candidates = await _map_section(section, doc.id, db)
+            all_candidates.extend(candidates)
+        except LlmDisabledError:
+            raise
+        except StructuredGenerationError as exc:
+            logger.warning(
+                "outline map: section '%s' failed (%s) — skipping",
+                section.get("title"),
+                exc,
+            )
+    return all_candidates
+
+
+# ---------------------------------------------------------------------------
+# Reduce step
+# ---------------------------------------------------------------------------
+
+async def _reduce(candidates: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Group candidates into chapters with pedagogical ordering."""
+    lines = []
+    for i, c in enumerate(candidates):
+        concepts = ", ".join(c["key_concepts"][:4]) or "—"
+        doc_tag = f' [doc:{c["source_doc_id"][:8]}]' if c.get("source_doc_id") else ""
+        lines.append(f"[{i}] {c['title']} ({c['difficulty']}) — {concepts}{doc_tag}")
+
+    prompt = (
+        "Group these lesson topics into a pedagogical course outline.\n\n"
+        "Rules:\n"
+        "- Order from foundational to advanced\n"
+        "- 2–6 lessons per chapter, at most 12 chapters\n"
+        "- Merge duplicate/near-duplicate topics (same concept from different documents) "
+        "into a single lesson, listing all their indices in candidate_indices\n"
+        "- Every index [0]–[{last}] must appear in exactly one lesson\n\n"
+        "Topics:\n{topics}"
+    ).format(last=len(candidates) - 1, topics="\n".join(lines))
+
+    return await generate_json(
+        prompt,
+        _REDUCE_SCHEMA,
+        system_prompt=_REDUCE_SYSTEM,
+        generation_params={"temp": 0.2},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persist step
+# ---------------------------------------------------------------------------
+
+def _persist_outline(
+    course_id: str,
+    outline: Dict[str, Any],
+    candidates: List[Dict[str, Any]],
+    db: Session,
+) -> None:
+    """Delete existing draft chapters for this course, write new draft outline."""
+    # Remove previous draft output (published chapters are untouched)
+    draft_chapters = (
+        db.query(Chapter)
+        .filter(Chapter.course_id == course_id, Chapter.status == "draft")
+        .all()
+    )
+    for ch in draft_chapters:
+        for ls in db.query(Lesson).filter(Lesson.chapter_id == ch.id).all():
+            db.delete(ls)
+        db.delete(ch)
+    db.flush()
+
+    for ch_idx, ch_data in enumerate(outline.get("chapters", [])):
+        chapter = Chapter(
+            id=str(uuid.uuid4()),
+            course_id=course_id,
+            title=ch_data["title"],
+            description=ch_data.get("description", ""),
+            order_index=ch_idx,
+            status="draft",
+        )
+        db.add(chapter)
+        db.flush()
+
+        for ls_idx, ls_data in enumerate(ch_data.get("lessons", [])):
+            # Aggregate source chunk IDs from all referenced candidates.
+            seen: set = set()
+            source_refs: List[str] = []
+            for cidx in ls_data.get("candidate_indices", []):
+                if 0 <= cidx < len(candidates):
+                    for cid in candidates[cidx].get("source_chunk_ids", []):
+                        if cid not in seen:
+                            seen.add(cid)
+                            source_refs.append(cid)
+
+            lesson = Lesson(
+                id=str(uuid.uuid4()),
+                chapter_id=chapter.id,
+                title=ls_data["title"],
+                description=ls_data.get("description", ""),
+                content="",
+                order_index=ls_idx,
+                status="draft",
+                source_refs_json=json.dumps(source_refs) if source_refs else None,
+            )
+            db.add(lesson)
+
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Main orchestrator
+# ---------------------------------------------------------------------------
+
+async def generate_outline(
+    course_id: str,
+    doc_ids: List[str],
+    db: Session,
+    run_id: str,
+    options: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Full map → reduce → persist pipeline for a course outline.
+
+    Updates GenerationRun.status/stage at each step so the frontend can
+    poll progress via GET /generation-runs/{run_id}.
+    """
+    run = db.query(GenerationRun).filter(GenerationRun.id == run_id).first()
+    if run is None:
+        raise ValueError(f"GenerationRun {run_id} not found")
+
+    _update_run(run, db, GenerationRunStatus.RUNNING, "init")
+
+    # ---- MAP ----
+    all_candidates: List[Dict[str, Any]] = []
+    docs = db.query(CourseDocument).filter(CourseDocument.id.in_(doc_ids)).all()
+
+    for doc_idx, doc in enumerate(docs):
+        stage = f"map_{doc_idx + 1}/{len(docs)}"
+        _update_run(run, db, GenerationRunStatus.RUNNING, stage)
+        try:
+            candidates = await _map_document(doc, db)
+            all_candidates.extend(candidates)
+            logger.info(
+                "outline map: doc %s → %d candidates", doc.id, len(candidates)
+            )
+        except LlmDisabledError as exc:
+            _update_run(run, db, GenerationRunStatus.ERROR, error=f"LLM disabled: {exc}")
+            return
+        except Exception as exc:
+            logger.exception("outline map: unexpected error for doc %s", doc.id)
+            _update_run(run, db, GenerationRunStatus.ERROR, error=str(exc))
+            return
+
+    if not all_candidates:
+        _update_run(
+            run, db, GenerationRunStatus.ERROR,
+            error="No candidates generated — documents may have no section structure",
+        )
+        return
+
+    # Cap for reduce context budget
+    candidates = all_candidates[:MAX_CANDIDATES_TOTAL]
+    if len(all_candidates) > MAX_CANDIDATES_TOTAL:
+        logger.info(
+            "outline: capped candidates from %d to %d for reduce step",
+            len(all_candidates), MAX_CANDIDATES_TOTAL,
+        )
+
+    # ---- REDUCE ----
+    _update_run(run, db, GenerationRunStatus.RUNNING, "reduce")
+    try:
+        outline = await _reduce(candidates)
+    except LlmDisabledError as exc:
+        _update_run(run, db, GenerationRunStatus.ERROR, error=f"LLM disabled: {exc}")
+        return
+    except StructuredGenerationError as exc:
+        _update_run(
+            run, db, GenerationRunStatus.ERROR,
+            error=f"Reduce failed after retries: {exc}",
+        )
+        return
+    except Exception as exc:
+        logger.exception("outline reduce: unexpected error")
+        _update_run(run, db, GenerationRunStatus.ERROR, error=str(exc))
+        return
+
+    # ---- PERSIST ----
+    _update_run(run, db, GenerationRunStatus.RUNNING, "persist")
+    try:
+        _persist_outline(course_id, outline, candidates, db)
+    except Exception as exc:
+        logger.exception("outline persist: DB write failed")
+        _update_run(run, db, GenerationRunStatus.ERROR, error=str(exc))
+        return
+
+    _update_run(run, db, GenerationRunStatus.DONE, "done")
+    n_chapters = len(outline.get("chapters", []))
+    n_lessons = sum(len(ch.get("lessons", [])) for ch in outline.get("chapters", []))
+    logger.info(
+        "outline done: course=%s run=%s → %d chapters, %d lessons",
+        course_id, run_id, n_chapters, n_lessons,
+    )

--- a/services/ai/app/services/qvac_structured.py
+++ b/services/ai/app/services/qvac_structured.py
@@ -1,0 +1,114 @@
+"""Client for QVAC /generate_json — schema-validated JSON from the local LLM.
+
+The Node worker enforces the schema (extraction + validation + correction
+retries on the model side); this client adds transport-level resilience:
+exponential backoff on connection errors and 5xx, typed exceptions for the
+two non-retryable outcomes (LLM disabled, schema never satisfied).
+
+Used by the course builder (outline generation, lesson metadata, groundedness
+judge) — anywhere a study feature needs structured output instead of prose.
+"""
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_QVAC_SERVICE_URL = os.getenv("QVAC_SERVICE_URL", "http://localhost:3001")
+
+# Generation client mirrors study_service: long read timeout for Qwen3-4B on
+# CPU; /generate_json may run up to 3 model passes (1 + 2 correction rounds).
+_client = httpx.AsyncClient(
+    base_url=_QVAC_SERVICE_URL,
+    timeout=httpx.Timeout(connect=5.0, read=300.0, write=10.0, pool=5.0),
+)
+
+_TRANSPORT_RETRIES = 3
+_BACKOFF_BASE_SECONDS = 1.0
+
+
+class LlmDisabledError(RuntimeError):
+    """QVAC is running in retrieval-only mode (QVAC_LLM_ENABLED=false)."""
+
+
+class StructuredGenerationError(RuntimeError):
+    """The model could not produce schema-valid JSON after worker-side retries."""
+
+    def __init__(self, message: str, errors: Optional[List[str]] = None, raw: str = ""):
+        super().__init__(message)
+        self.errors = errors or []
+        self.raw = raw
+
+
+async def generate_json(
+    prompt: str,
+    schema: Dict[str, Any],
+    *,
+    context: Optional[List[Dict[str, str]]] = None,
+    system_prompt: Optional[str] = None,
+    max_retries: Optional[int] = None,
+    generation_params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Return a JSON value guaranteed to validate against *schema*.
+
+    context items follow the /generate convention: {"label": str, "text": str}.
+    Raises LlmDisabledError, StructuredGenerationError, or httpx errors when
+    the worker stays unreachable after transport retries.
+    """
+    payload: Dict[str, Any] = {"prompt": prompt, "schema": schema}
+    if context:
+        payload["context"] = context
+    if system_prompt:
+        payload["systemPrompt"] = system_prompt
+    if max_retries is not None:
+        payload["maxRetries"] = max_retries
+    if generation_params:
+        payload["generationParams"] = generation_params
+
+    last_exc: Optional[Exception] = None
+    for attempt in range(1, _TRANSPORT_RETRIES + 1):
+        try:
+            resp = await _client.post("/generate_json", json=payload)
+        except httpx.TransportError as exc:
+            last_exc = exc
+            logger.warning(
+                "QVAC /generate_json transport error (attempt %d/%d): %s",
+                attempt, _TRANSPORT_RETRIES, exc,
+            )
+            if attempt < _TRANSPORT_RETRIES:
+                await asyncio.sleep(_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1))
+            continue
+
+        if resp.status_code == 503:
+            raise LlmDisabledError(resp.json().get("error", "LLM disabled"))
+        if resp.status_code == 422:
+            body = resp.json()
+            raise StructuredGenerationError(
+                body.get("error", "schema validation failed"),
+                errors=body.get("errors"),
+                raw=body.get("raw", ""),
+            )
+        if resp.status_code >= 500:
+            last_exc = httpx.HTTPStatusError(
+                f"QVAC /generate_json returned {resp.status_code}",
+                request=resp.request, response=resp,
+            )
+            logger.warning(
+                "QVAC /generate_json server error %d (attempt %d/%d)",
+                resp.status_code, attempt, _TRANSPORT_RETRIES,
+            )
+            if attempt < _TRANSPORT_RETRIES:
+                await asyncio.sleep(_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1))
+            continue
+
+        resp.raise_for_status()
+        body = resp.json()
+        if attempt > 1:
+            logger.info("QVAC /generate_json succeeded on transport attempt %d", attempt)
+        return body["json"]
+
+    assert last_exc is not None
+    raise last_exc

--- a/services/ai/app/services/study_service.py
+++ b/services/ai/app/services/study_service.py
@@ -13,7 +13,7 @@ import re
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import AsyncGenerator, List, Optional
 
 import httpx
 
@@ -29,9 +29,17 @@ logger = logging.getLogger(__name__)
 _QVAC_SERVICE_URL = os.getenv("QVAC_SERVICE_URL", "http://localhost:3001")
 _TOP_K = int(os.getenv("RAG_TOP_K", "5"))
 
+# Retrieval client: 45 s read covers dense search + BM25 on large corpora.
 _qvac_client = httpx.AsyncClient(
     base_url=_QVAC_SERVICE_URL,
     timeout=httpx.Timeout(connect=5.0, read=45.0, write=10.0, pool=5.0),
+)
+
+# Generation client: 120 s read covers Qwen3-4B Q4 on CPU-only hardware for long
+# derivations/comparisons. Kept separate so retrieval timeouts remain tight.
+_qvac_gen_client = httpx.AsyncClient(
+    base_url=_QVAC_SERVICE_URL,
+    timeout=httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0),
 )
 
 
@@ -104,10 +112,19 @@ _SYSTEM_PROMPTS = {
         "3. After the model answer, add one follow-up question that a professor would ask"
         " to probe deeper understanding.\n"
         "4. Use exact Bitcoin terminology from the document.\n"
-        "5. Format each entry as:\n"
-        "Q<n>: <question>\n"
+        "5. CRITICAL — use EXACTLY these labels on their own lines, with a colon, no variations:\n"
+        "   Q1: / Q2: / Q3:\n"
+        "   Model answer:\n"
+        "   Follow-up:\n"
+        "   Any other label will break the parser that students use to see their results.\n"
+        "6. Format:\n"
+        "Q1: <question>\n"
         "Model answer: <answer with [ref_N] citations>\n"
-        "Follow-up: <deeper question>"
+        "Follow-up: <deeper question as a question ending with ?>\n"
+        "\n"
+        "Q2: <question>\n"
+        "Model answer: <answer with [ref_N] citations>\n"
+        "Follow-up: <deeper question ending with ?>"
     ),
     StudyAction.DERIVE: (
         "You are an expert Bitcoin tutor skilled in formal derivations, at BitPolito Academy.\n"
@@ -123,11 +140,15 @@ _SYSTEM_PROMPTS = {
         "You are an expert Bitcoin tutor at BitPolito Academy.\n"
         "Using ONLY the provided context, produce a structured comparison of the requested concepts.\n"
         "RULES:\n"
-        "1. Use a parallel-list or table format with clearly labelled columns for each concept.\n"
-        "2. Compare on the same dimensions (e.g. security model, scalability, consensus"
-        " mechanism) — do not mix apples and oranges.\n"
-        "3. Use exact technical terms from the document; cite sources as [ref_N].\n"
-        "4. Conclude with a 1-paragraph synthesis that draws out the most important"
+        "1. First, identify exactly 3–4 comparison dimensions that are relevant to BOTH concepts"
+        " and that appear in the source material. List them explicitly as:\n"
+        "   **Dimensions: <dim1>, <dim2>, <dim3>[, <dim4>]**\n"
+        "2. Then produce a Markdown table with one row per dimension and one column per concept.\n"
+        "   | Dimension | Concept A | Concept B |\n"
+        "   |---|---|---|\n"
+        "   Fill every cell with a concise value drawn from the context.\n"
+        "3. Use exact technical terms from the document; cite sources inline as [ref_N].\n"
+        "4. Conclude with a 1-paragraph synthesis drawing out the most important"
         " trade-off or distinction, citing [ref_N]."
     ),
 }
@@ -334,6 +355,9 @@ async def _retrieve_multi(
     return raw_answers[0] if raw_answers else "", combined
 
 
+_THINKING_ACTIONS = frozenset({StudyAction.DERIVE})
+
+
 async def _generate(action: StudyAction, question: str, context: str) -> Optional[str]:
     """Call QVAC /generate with the action-specific system prompt (local LLM via QVAC SDK).
 
@@ -342,15 +366,22 @@ async def _generate(action: StudyAction, question: str, context: str) -> Optiona
 
     Returns None when QVAC is unreachable or returns an empty answer, allowing
     the caller to fall back to the raw retrieval context.
+
+    preserveMarkdown is always True for study actions — their system prompts request
+    structured output (tables, numbered steps, [ref_N] markers) that must not be stripped.
+    enableThinking is True only for DERIVE to leverage Qwen3's step-by-step reasoning.
     """
     system_prompt = _SYSTEM_PROMPTS.get(action, "")
+    enable_thinking = action in _THINKING_ACTIONS
     try:
-        resp = await _qvac_client.post(
+        resp = await _qvac_gen_client.post(
             "/generate",
             json={
                 "question": question,
                 "context": [{"label": "", "text": context}],
                 "systemPrompt": system_prompt,
+                "preserveMarkdown": True,
+                "enableThinking": enable_thinking,
             },
         )
         resp.raise_for_status()
@@ -359,6 +390,45 @@ async def _generate(action: StudyAction, question: str, context: str) -> Optiona
     except httpx.HTTPError as exc:
         logger.warning("QVAC /generate failed for action '%s': %s", action.value, exc)
         return None
+
+
+async def _stream_generate(
+    action: StudyAction, question: str, context: str
+) -> AsyncGenerator[str, None]:
+    """Call QVAC /stream with the action-specific system prompt and yield raw tokens.
+
+    Used by stream_dispatch() to provide progressive display for slow generations on
+    limited hardware.  enableThinking follows the same rules as _generate().
+    """
+    system_prompt = _SYSTEM_PROMPTS.get(action, "")
+    enable_thinking = action in _THINKING_ACTIONS
+    try:
+        async with _qvac_gen_client.stream(
+            "POST",
+            "/stream",
+            json={
+                "question": question,
+                "context": [{"label": "", "text": context}],
+                "systemPrompt": system_prompt,
+                "enableThinking": enable_thinking,
+            },
+        ) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if not line.startswith("data:"):
+                    continue
+                payload = line[5:].strip()
+                if payload == "[DONE]":
+                    return
+                try:
+                    token = json.loads(payload)
+                    if isinstance(token, str):
+                        yield token
+                except (json.JSONDecodeError, ValueError):
+                    pass
+    except httpx.HTTPError as exc:
+        logger.warning("QVAC /stream failed for action '%s': %s", action.value, exc)
+        return
 
 
 async def _route(
@@ -492,3 +562,119 @@ async def dispatch(
     finally:
         trace.duration_ms = round((time.perf_counter() - started_at) * 1000, 2)
         logger.info("dispatch_trace %s", json.dumps(dataclasses.asdict(trace)))
+
+
+# Actions that must be fully buffered before the frontend can parse the output.
+# QUIZ needs the complete text to split on question delimiters.
+# ORAL needs the complete text to parse Q/model-answer/follow-up blocks.
+# RETRIEVE has no generation at all.
+_BUFFERED_ACTIONS = frozenset({StudyAction.QUIZ, StudyAction.ORAL, StudyAction.RETRIEVE})
+
+_CITATIONS_SENTINEL = "\x00CITATIONS\x00"
+
+
+async def stream_dispatch(
+    question: str,
+    course_id: str,
+    action: StudyAction,
+    rag_only: bool = False,
+) -> AsyncGenerator[str, None]:
+    """Streaming variant of dispatch().
+
+    Yields raw token strings followed by a citations sentinel for the frontend
+    to parse. Uses the same retrieval pipeline as dispatch() and shares its
+    semantic cache — a cache hit short-circuits retrieval and generation entirely,
+    returning the cached answer as a single chunk at the speed of Redis.
+
+    QUIZ, ORAL, and RETRIEVE are always buffered (full output needed for parsing).
+    All other actions stream token-by-token via QVAC /stream.
+
+    Sentinel format: \\x00CITATIONS\\x00<json-array-of-SourceChunk-dicts>
+    """
+    if len(question.strip()) < 5:
+        raise ValueError("Query too short — must be at least 5 characters")
+
+    # --- Semantic cache lookup (shared with dispatch()) ---
+    from app.services.cache_service import get_cached, set_cached  # noqa: PLC0415
+    cache_key = f"{question} [action:{action.value}]" + (" [rag_only]" if rag_only else "")
+    cached = get_cached(cache_key, course_id)
+    if cached is not None:
+        yield cached["answer"]
+        yield _CITATIONS_SENTINEL + json.dumps(cached.get("citations", []))
+        return
+
+    meta = STUDY_ACTION_REGISTRY[action]
+
+    # Retrieval — identical to dispatch()
+    raw_answer = ""
+    pack = _empty_pack(question, action)
+    if meta.retrieval_required:
+        raw_answer, pack = await _retrieve_multi(question, course_id, action)
+
+    # Build citations list for the sentinel payload
+    def _make_sources(chunks: list[EvidenceChunk]) -> List[SourceChunk]:
+        return [
+            SourceChunk(
+                snippet=c.text,
+                score=c.score,
+                label=c.anchor.doc_name,
+                page=c.anchor.page or 0,
+                slide=c.anchor.slide or 0,
+                section=c.anchor.section or "",
+                doc_id=c.anchor.doc_id,
+            )
+            for c in chunks
+        ]
+
+    def _cache_and_sentinel(answer: str, sources: List[SourceChunk]) -> str:
+        citations_raw = [dataclasses.asdict(s) for s in sources]
+        set_cached(cache_key, course_id, {
+            "answer": answer,
+            "citations": citations_raw,
+            "retrieval_used": bool(sources),
+        })
+        return _CITATIONS_SENTINEL + json.dumps(citations_raw)
+
+    # Retrieve-only or rag_only: emit context block as a single chunk, then citations
+    if not meta.generation_required or rag_only:
+        answer = pack.context_block() or raw_answer or "No relevant content found."
+        sources = _make_sources(pack.chunks)
+        yield answer
+        yield _cache_and_sentinel(answer, sources)
+        return
+
+    # Buffered actions (QUIZ, ORAL): generate fully, emit, cache, sentinel
+    if action in _BUFFERED_ACTIONS:
+        generated = await _generate(action, question, pack.context_block())
+        if generated:
+            answer = generated
+            sources = _parse_citations(generated, pack)
+        else:
+            answer = raw_answer or "No relevant content found."
+            sources = _make_sources(pack.chunks)
+        yield answer
+        yield _cache_and_sentinel(answer, sources)
+        return
+
+    # Streaming actions: stream tokens, accumulate for citation parsing + cache write
+    accumulated: list[str] = []
+    async for token in _stream_generate(action, question, pack.context_block()):
+        accumulated.append(token)
+        yield token
+
+    if accumulated:
+        full_text = "".join(accumulated)
+        sources = _parse_citations(full_text, pack)
+        yield _cache_and_sentinel(full_text, sources)
+    else:
+        # Stream yielded nothing — fall back to buffered generate
+        generated = await _generate(action, question, pack.context_block())
+        if generated:
+            yield generated
+            sources = _parse_citations(generated, pack)
+            yield _cache_and_sentinel(generated, sources)
+        else:
+            fallback = raw_answer or "No relevant content found."
+            sources = _make_sources(pack.chunks)
+            yield fallback
+            yield _cache_and_sentinel(fallback, sources)

--- a/services/ai/app/workers/arq_worker.py
+++ b/services/ai/app/workers/arq_worker.py
@@ -35,8 +35,24 @@ async def reindex_document_qvac(ctx, document_id: str, course_id: str) -> None:
     )
 
 
+async def generate_course_outline(
+    ctx, course_id: str, doc_ids: list, run_id: str
+) -> None:
+    """ARQ job: map-reduce pipeline that generates draft Chapter/Lesson rows."""
+    from app.db.session import get_db_context
+    from app.services import outline_service
+
+    with get_db_context() as db:
+        await outline_service.generate_outline(
+            course_id=course_id,
+            doc_ids=doc_ids,
+            db=db,
+            run_id=run_id,
+        )
+
+
 class WorkerSettings:
-    functions = [ingest_document, reindex_document_qvac]
+    functions = [ingest_document, reindex_document_qvac, generate_course_outline]
     redis_settings = RedisSettings.from_dsn(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
     job_timeout = 600
     max_tries = 2

--- a/services/ai/app/workers/arq_worker.py
+++ b/services/ai/app/workers/arq_worker.py
@@ -51,8 +51,26 @@ async def generate_course_outline(
         )
 
 
+async def generate_course_content(ctx, course_id: str, run_id: str) -> None:
+    """ARQ job: generate content for all draft lessons in a course."""
+    from app.db.session import get_db_context
+    from app.services import lesson_service
+
+    with get_db_context() as db:
+        await lesson_service.generate_course_content(
+            course_id=course_id,
+            db=db,
+            run_id=run_id,
+        )
+
+
 class WorkerSettings:
-    functions = [ingest_document, reindex_document_qvac, generate_course_outline]
+    functions = [
+        ingest_document,
+        reindex_document_qvac,
+        generate_course_outline,
+        generate_course_content,
+    ]
     redis_settings = RedisSettings.from_dsn(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
     job_timeout = 600
     max_tries = 2

--- a/services/ai/app/workers/pipeline.py
+++ b/services/ai/app/workers/pipeline.py
@@ -542,21 +542,47 @@ def chunk_pages(pages: list[dict], doc_id: str) -> list[dict]:
     return chunks
 
 
+def _clean_section_title(title: str) -> str:
+    """Strip markdown emphasis residue from heading titles (e.g. '**Prologue**')."""
+    return re.sub(r'\*{1,3}|_{1,3}|`', '', title or '').strip()
+
+
 def build_parent_child_chunks(
     pages: list[dict],
     doc_id: str,
-) -> tuple[list[dict], list[dict]]:
+) -> tuple[list[dict], list[dict], list[dict]]:
     """Chunking gerarchico: parent (1200 parole) → child (150 parole).
 
     I child chunk sono le unità di retrieval indicizzate in QVAC.
     I parent chunk forniscono contesto esteso al LLM dopo il retrieval.
 
-    Ritorna (parent_chunks, child_chunks).
+    Oltre ai chunk, raccoglie gli eventi sezione in ordine di documento:
+    ogni heading markdown produce {"title", "level", "page_start",
+    "page_end", "parent_chunk_ids"}; i parent generati prima del primo
+    heading finiscono in una sezione preambolo con title="". La lista
+    piatta viene annidata da build_section_tree().
+
+    Ritorna (parent_chunks, child_chunks, section_events).
     """
     parents: list[dict] = []
     children: list[dict] = []
+    section_events: list[dict] = []
     current_section = ""
     parent_idx = 0
+
+    def _record_parent_in_section(parent: dict) -> None:
+        if not section_events:
+            # Content before the first heading — untitled preamble section.
+            section_events.append({
+                "title": "",
+                "level": 1,
+                "page_start": parent["citation_page"],
+                "page_end": parent["citation_page"],
+                "parent_chunk_ids": [],
+            })
+        event = section_events[-1]
+        event["parent_chunk_ids"].append(parent["id"])
+        event["page_end"] = max(event["page_end"], parent["citation_page"])
 
     for page_data in pages:
         page_num = page_data["page"]
@@ -576,9 +602,17 @@ def build_parent_child_chunks(
                 continue
 
             if btype == "heading":
+                level = len(re.match(r'^#{1,4}', btext).group(0))
                 heading_text = re.sub(r'^#{1,4}\s+', '', btext).strip()
                 current_section = heading_text
                 pending_heading = btext
+                section_events.append({
+                    "title": _clean_section_title(heading_text),
+                    "level": level,
+                    "page_start": page_num,
+                    "page_end": page_num,
+                    "parent_chunk_ids": [],
+                })
                 continue
 
             full_text = f"{pending_heading}\n\n{btext}" if pending_heading else btext
@@ -597,6 +631,7 @@ def build_parent_child_chunks(
 
                 parent = _make_parent(doc_id, parent_idx, page_num, parent_text, current_section)
                 parents.append(parent)
+                _record_parent_in_section(parent)
 
                 # Genera child chunk dal parent
                 if btype in ("table", "formula", "code") or wc <= _CHILD_WORDS:
@@ -642,7 +677,71 @@ def build_parent_child_chunks(
 
                 parent_idx += 1
 
-    return parents, children
+    return parents, children, section_events
+
+
+def build_section_tree(section_events: list[dict]) -> list[dict]:
+    """Annida gli eventi sezione piatti in un albero per livello heading.
+
+    Ogni nodo: {"title", "level", "page_start", "page_end",
+    "parent_chunk_ids", "children"}. Un heading di livello L diventa figlio
+    dell'ultimo heading aperto con livello < L (stack-based, ordine di
+    documento). page_end è propagato bottom-up sui discendenti, così lo span
+    di un capitolo copre tutte le sue sottosezioni.
+
+    È la fonte della struttura per il course builder (outline generation):
+    parent_chunk_ids àncora ogni sezione ai ChunkParent da cui generare.
+    """
+    roots: list[dict] = []
+    stack: list[dict] = []
+
+    for event in section_events:
+        node = {**event, "parent_chunk_ids": list(event["parent_chunk_ids"]), "children": []}
+        while stack and stack[-1]["level"] >= node["level"]:
+            stack.pop()
+        if stack:
+            stack[-1]["children"].append(node)
+        else:
+            roots.append(node)
+        stack.append(node)
+
+    def _propagate_page_end(node: dict) -> int:
+        for child in node["children"]:
+            node["page_end"] = max(node["page_end"], _propagate_page_end(child))
+        return node["page_end"]
+
+    for root in roots:
+        _propagate_page_end(root)
+
+    return roots
+
+
+def build_section_events_from_parents(parent_rows: list) -> list[dict]:
+    """Backfill: ricostruisce eventi sezione piatti dalle righe ChunkParent.
+
+    Per i documenti ingestionati prima dell'introduzione del section tree il
+    file sorgente può non esistere più (run() lo elimina a fine pipeline),
+    ma chunk_parent conserva citation_section e citation_page per parent.
+    Raggruppando le run consecutive della stessa sezione (righe ordinate per
+    id, che codifica l'ordine di documento) si ottiene un albero piatto di
+    livello 1 — senza gerarchia heading, ma sufficiente per l'outline.
+    """
+    events: list[dict] = []
+    for row in parent_rows:
+        title = _clean_section_title(row.citation_section)
+        page = row.citation_page or 0
+        if not events or events[-1]["title"] != title:
+            events.append({
+                "title": title,
+                "level": 1,
+                "page_start": page,
+                "page_end": page,
+                "parent_chunk_ids": [],
+            })
+        event = events[-1]
+        event["parent_chunk_ids"].append(row.id)
+        event["page_end"] = max(event["page_end"], page)
+    return events
 
 
 # ---------------------------------------------------------------------------
@@ -935,7 +1034,9 @@ def run(
             # Stage 3 — CHUNKING (parent-child hierarchy)
             # ------------------------------------------------------------------
             _set_stage(doc, DocumentProcessingStage.CHUNKING, db)
-            parent_chunks, raw_children = build_parent_child_chunks(pages, document_id)
+            parent_chunks, raw_children, section_events = build_parent_child_chunks(
+                pages, document_id
+            )
 
             # ------------------------------------------------------------------
             # Stage 3b — QUALITY FILTER (child chunks only)
@@ -1053,6 +1154,7 @@ def run(
             doc.page_count = page_count if page_count else None
             doc.extracted_text_preview = full_text[:500]
             doc.sections_json = json.dumps(sections)
+            doc.section_tree_json = json.dumps(build_section_tree(section_events))
             doc.sample_chunks_json = json.dumps(sample)
             db.commit()
 

--- a/services/ai/tests/integration/test_content_api.py
+++ b/services/ai/tests/integration/test_content_api.py
@@ -1,0 +1,319 @@
+"""Integration tests for content_api — Phase 3 course builder.
+
+Uses TestClient (ASGI) with an in-memory SQLite DB injected via dependency_overrides.
+All LLM calls are mocked via patch so tests are fully deterministic.
+"""
+import json
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.db.models import (
+    Base,
+    Chapter,
+    ChunkParent,
+    Course,
+    GenerationRun,
+    GenerationRunStatus,
+    Lesson,
+    OptionChoice,
+    Question,
+    QuestionType,
+    Quiz,
+    QuizScope,
+    Section,
+)
+from app.db.session import get_db
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# In-memory DB fixture
+# ---------------------------------------------------------------------------
+
+def _make_engine():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture()
+def db_session():
+    engine = _make_engine()
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    yield db
+    db.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    """TestClient with DB override and ARQ pool set to None.
+
+    Intentionally avoids `with TestClient(app) as c` so that the ASGI lifespan
+    is NOT triggered — lifespan calls init_db() against the real on-disk DB,
+    which is irrelevant (and fragile) during unit/integration tests.
+    """
+    def _override():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override
+    app.state.arq_pool = None  # force BackgroundTasks path
+    c = TestClient(app, raise_server_exceptions=True)
+    yield c
+    app.dependency_overrides.pop(get_db, None)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _seed_course(db):
+    section = Section(id=str(uuid.uuid4()), title="Test")
+    db.add(section)
+    course = Course(id=str(uuid.uuid4()), title="Test Course", section_id=section.id)
+    db.add(course)
+    db.commit()
+    db.refresh(course)
+    return course
+
+
+def _seed_draft_chapter(db, course_id):
+    ch = Chapter(
+        id=str(uuid.uuid4()),
+        course_id=course_id,
+        title="Chapter 1",
+        order_index=0,
+        status="draft",
+    )
+    db.add(ch)
+    db.commit()
+    db.refresh(ch)
+    return ch
+
+
+def _seed_lesson(db, chapter_id, source_refs=None, status="draft", content=""):
+    ls = Lesson(
+        id=str(uuid.uuid4()),
+        chapter_id=chapter_id,
+        title="Lesson 1",
+        content=content,
+        order_index=0,
+        status=status,
+        source_refs_json=json.dumps(source_refs) if source_refs else None,
+    )
+    db.add(ls)
+    db.commit()
+    db.refresh(ls)
+    return ls
+
+
+def _seed_parent(db, cid, course_id, text="Bitcoin is a peer-to-peer cash system."):
+    p = ChunkParent(
+        id=cid,
+        doc_id="doc1",
+        course_id=course_id,
+        text=text,
+    )
+    db.add(p)
+    db.commit()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# POST /courses/{id}/content/generate
+# ---------------------------------------------------------------------------
+
+class TestGenerateContent:
+    def test_returns_202_with_run_id(self, client, db_session):
+        course = _seed_course(db_session)
+        ch = _seed_draft_chapter(db_session, course.id)
+        _seed_lesson(db_session, ch.id, source_refs=["p1"])
+
+        # Prevent the background task from running in a separate DB context
+        with patch("app.api.content_api._run_content_bg", new_callable=AsyncMock):
+            resp = client.post(
+                f"/api/courses/{course.id}/content/generate", json={}
+            )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert "run_id" in body
+        assert body["status"] == GenerationRunStatus.QUEUED
+        assert body["draft_lessons"] == 1
+
+        run = db_session.query(GenerationRun).filter(
+            GenerationRun.id == body["run_id"]
+        ).first()
+        assert run is not None
+        assert run.course_id == course.id
+
+    def test_422_when_no_draft_lessons(self, client, db_session):
+        course = _seed_course(db_session)
+        # Chapter is published — lessons won't appear in draft count
+        ch = Chapter(
+            id=str(uuid.uuid4()),
+            course_id=course.id,
+            title="Ch",
+            order_index=0,
+            status="published",
+        )
+        db_session.add(ch)
+        db_session.commit()
+        _seed_lesson(db_session, ch.id)
+
+        resp = client.post(
+            f"/api/courses/{course.id}/content/generate", json={}
+        )
+        assert resp.status_code == 422
+
+    def test_404_when_course_not_found(self, client, db_session):
+        resp = client.post(
+            "/api/courses/nonexistent-course/content/generate", json={}
+        )
+        assert resp.status_code == 404
+
+    def test_422_when_course_has_no_chapters(self, client, db_session):
+        course = _seed_course(db_session)
+        resp = client.post(
+            f"/api/courses/{course.id}/content/generate", json={}
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /courses/{id}/publish
+# ---------------------------------------------------------------------------
+
+class TestPublishCourse:
+    def test_publishes_chapters_with_all_published_lessons(self, client, db_session):
+        course = _seed_course(db_session)
+        ch = _seed_draft_chapter(db_session, course.id)
+        _seed_lesson(db_session, ch.id, status="published", content="good")
+        _seed_lesson(db_session, ch.id, status="published", content="good")
+
+        resp = client.post(f"/api/courses/{course.id}/publish")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["published_chapters"] == 1
+        assert body["published_lessons"] == 2
+        assert body["skipped_chapters"] == 0
+
+        db_session.refresh(ch)
+        assert ch.status == "published"
+
+    def test_skips_chapters_with_needs_review_lessons(self, client, db_session):
+        course = _seed_course(db_session)
+        ch = _seed_draft_chapter(db_session, course.id)
+        _seed_lesson(db_session, ch.id, status="published", content="ok")
+        _seed_lesson(db_session, ch.id, status="needs_review", content="problem")
+
+        resp = client.post(f"/api/courses/{course.id}/publish")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["published_chapters"] == 0
+        assert body["skipped_chapters"] == 1
+
+    def test_404_when_course_not_found(self, client, db_session):
+        resp = client.post("/api/courses/nonexistent/publish")
+        assert resp.status_code == 404
+
+    def test_empty_result_when_no_draft_chapters(self, client, db_session):
+        course = _seed_course(db_session)
+        resp = client.post(f"/api/courses/{course.id}/publish")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["published_chapters"] == 0
+        assert body["published_lessons"] == 0
+        assert body["skipped_chapters"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /lessons/{id}/content
+# ---------------------------------------------------------------------------
+
+class TestGetLessonContent:
+    def test_returns_lesson_content(self, client, db_session):
+        course = _seed_course(db_session)
+        ch = _seed_draft_chapter(db_session, course.id)
+        _seed_parent(db_session, "p1", course.id)
+        ls = _seed_lesson(
+            db_session, ch.id,
+            source_refs=["p1"],
+            status="published",
+            content="## Bitcoin\n\nBitcoin is a currency.",
+        )
+
+        resp = client.get(f"/api/lessons/{ls.id}/content")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == ls.id
+        assert body["title"] == "Lesson 1"
+        assert "Bitcoin" in body["content"]
+        assert body["status"] == "published"
+        assert body["source_refs"] == ["p1"]
+        assert body["quiz"] is None
+
+    def test_returns_quiz_when_present(self, client, db_session):
+        course = _seed_course(db_session)
+        ch = _seed_draft_chapter(db_session, course.id)
+        ls = _seed_lesson(db_session, ch.id, status="published", content="content")
+
+        quiz = Quiz(
+            id=str(uuid.uuid4()),
+            scope=QuizScope.LESSON,
+            title="Quiz: Lesson 1",
+            passing_score=70,
+            lesson_id=ls.id,
+        )
+        db_session.add(quiz)
+        db_session.flush()
+        q = Question(
+            id=str(uuid.uuid4()),
+            quiz_id=quiz.id,
+            qtype=QuestionType.MCQ,
+            prompt="What is Bitcoin?",
+            order_index=0,
+        )
+        db_session.add(q)
+        db_session.flush()
+        for key in ["A", "B", "C", "D"]:
+            db_session.add(OptionChoice(
+                id=str(uuid.uuid4()),
+                question_id=q.id,
+                label=f"{key}) Option {key}",
+                is_correct=(key == "A"),
+            ))
+        db_session.commit()
+
+        resp = client.get(f"/api/lessons/{ls.id}/content")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["quiz"] is not None
+        assert body["quiz"]["id"] == quiz.id
+        assert len(body["quiz"]["questions"]) == 1
+        assert len(body["quiz"]["questions"][0]["options"]) == 4
+        correct = [o for o in body["quiz"]["questions"][0]["options"] if o["is_correct"]]
+        assert len(correct) == 1
+
+    def test_404_when_lesson_not_found(self, client, db_session):
+        resp = client.get("/api/lessons/nonexistent-lesson/content")
+        assert resp.status_code == 404
+
+    def test_empty_source_refs_when_none(self, client, db_session):
+        course = _seed_course(db_session)
+        ch = _seed_draft_chapter(db_session, course.id)
+        ls = _seed_lesson(db_session, ch.id, source_refs=None, content="content")
+
+        resp = client.get(f"/api/lessons/{ls.id}/content")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["source_refs"] == []

--- a/services/ai/tests/integration/test_document_structure_api.py
+++ b/services/ai/tests/integration/test_document_structure_api.py
@@ -1,0 +1,120 @@
+"""Integration tests for GET /api/documents/{id}/structure.
+
+Three sources: "ingest" (tree persisted by the pipeline), "rebuilt" (flat
+tree from chunk_parent for legacy documents), "unavailable" (not READY or
+nothing indexed). Uses the in-memory SQLite fixtures from conftest.
+"""
+import json
+import uuid
+
+import pytest
+
+from app.db.models import ChunkParent, CourseDocument, DocumentStatus
+from tests.conftest import make_course_with_lessons
+
+_TREE = [
+    {
+        "title": "Chapter One",
+        "level": 1,
+        "page_start": 1,
+        "page_end": 9,
+        "parent_chunk_ids": ["d_p0000"],
+        "children": [
+            {
+                "title": "Section 1.1",
+                "level": 2,
+                "page_start": 2,
+                "page_end": 9,
+                "parent_chunk_ids": ["d_p0001"],
+                "children": [],
+            }
+        ],
+    }
+]
+
+
+def _make_document(db, course_id: str, **overrides) -> CourseDocument:
+    fields = {
+        "id": str(uuid.uuid4()),
+        "course_id": course_id,
+        "filename": "test.pdf",
+        "size": 1234,
+        "status": DocumentStatus.READY,
+        **overrides,
+    }
+    doc = CourseDocument(**fields)
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    return doc
+
+
+@pytest.mark.integration
+def test_structure_returns_ingest_tree(client, db):
+    course, _ = make_course_with_lessons(db)
+    doc = _make_document(db, course.id, section_tree_json=json.dumps(_TREE))
+
+    resp = client.get(f"/api/documents/{doc.id}/structure")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["source"] == "ingest"
+    assert body["document_id"] == doc.id
+    assert body["tree"][0]["title"] == "Chapter One"
+    assert body["tree"][0]["children"][0]["title"] == "Section 1.1"
+    assert body["tree"][0]["children"][0]["parent_chunk_ids"] == ["d_p0001"]
+
+
+@pytest.mark.integration
+def test_structure_rebuilds_flat_tree_from_chunk_parents(client, db):
+    course, _ = make_course_with_lessons(db)
+    doc = _make_document(db, course.id)  # READY, no section_tree_json
+    for idx, (section, page) in enumerate([("Intro", 1), ("Intro", 2), ("Mining", 5)]):
+        db.add(ChunkParent(
+            id=f"{doc.id}_p{idx:04d}",
+            doc_id=doc.id,
+            course_id=course.id,
+            text="parent text",
+            citation_section=section,
+            citation_page=page,
+        ))
+    db.commit()
+
+    resp = client.get(f"/api/documents/{doc.id}/structure")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["source"] == "rebuilt"
+    assert [n["title"] for n in body["tree"]] == ["Intro", "Mining"]
+    assert body["tree"][0]["page_start"] == 1
+    assert body["tree"][0]["page_end"] == 2
+    assert len(body["tree"][0]["parent_chunk_ids"]) == 2
+    # Rebuilt trees are not persisted — reindex produces the real one.
+    db.refresh(doc)
+    assert doc.section_tree_json is None
+
+
+@pytest.mark.integration
+def test_structure_unavailable_when_not_ready(client, db):
+    course, _ = make_course_with_lessons(db)
+    doc = _make_document(db, course.id, status=DocumentStatus.PROCESSING)
+
+    resp = client.get(f"/api/documents/{doc.id}/structure")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["source"] == "unavailable"
+    assert body["tree"] is None
+
+
+@pytest.mark.integration
+def test_structure_unavailable_when_no_parents(client, db):
+    course, _ = make_course_with_lessons(db)
+    doc = _make_document(db, course.id)  # READY but nothing in chunk_parent
+
+    resp = client.get(f"/api/documents/{doc.id}/structure")
+    assert resp.status_code == 200
+    assert resp.json()["source"] == "unavailable"
+
+
+@pytest.mark.integration
+def test_structure_unknown_document_404(client, db):
+    resp = client.get(f"/api/documents/{uuid.uuid4()}/structure")
+    assert resp.status_code == 404

--- a/services/ai/tests/integration/test_outline_api.py
+++ b/services/ai/tests/integration/test_outline_api.py
@@ -1,0 +1,321 @@
+"""Integration tests for outline API endpoints (Phase 2).
+
+POST   /api/courses/{id}/outline/generate
+GET    /api/courses/{id}/outline
+PATCH  /api/courses/{id}/outline
+GET    /api/generation-runs/{run_id}
+
+Uses the in-memory SQLite fixtures from conftest. LLM calls are mocked so no
+real QVAC service is needed.
+"""
+import json
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.db.models import (
+    Chapter,
+    ChunkParent,
+    CourseDocument,
+    DocumentStatus,
+    GenerationRun,
+    GenerationRunStatus,
+    Lesson,
+)
+from tests.conftest import make_course_with_lessons
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ready_doc(db, course_id, tree=None):
+    doc = CourseDocument(
+        id=str(uuid.uuid4()),
+        course_id=course_id,
+        filename="test.pdf",
+        size=1000,
+        status=DocumentStatus.READY,
+        section_tree_json=json.dumps(tree) if tree is not None else None,
+    )
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    return doc
+
+
+def _make_run(db, course_id, status=GenerationRunStatus.DONE):
+    run = GenerationRun(
+        id=str(uuid.uuid4()),
+        course_id=course_id,
+        doc_ids_json=json.dumps([]),
+        status=status,
+        prompt_version="v1",
+        created_at="2026-01-01T00:00:00",
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+    return run
+
+
+def _make_draft_chapter(db, course_id, title="Draft Chapter", order_index=0):
+    chapter = Chapter(
+        id=str(uuid.uuid4()),
+        course_id=course_id,
+        title=title,
+        order_index=order_index,
+        status="draft",
+    )
+    db.add(chapter)
+    db.flush()
+    lesson = Lesson(
+        id=str(uuid.uuid4()),
+        chapter_id=chapter.id,
+        title="Draft Lesson",
+        content="",
+        order_index=0,
+        status="draft",
+        source_refs_json=json.dumps(["chunk1"]),
+    )
+    db.add(lesson)
+    db.commit()
+    db.refresh(chapter)
+    db.refresh(lesson)
+    return chapter, lesson
+
+
+# ---------------------------------------------------------------------------
+# GET /api/courses/{id}/outline — empty
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_get_outline_empty(client, db):
+    course, _ = make_course_with_lessons(db)
+
+    resp = client.get(f"/api/courses/{course.id}/outline")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["course_id"] == course.id
+    assert body["chapters"] == []
+
+
+# ---------------------------------------------------------------------------
+# GET /api/courses/{id}/outline — with draft chapters
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_get_outline_returns_draft_chapters(client, db):
+    course, _ = make_course_with_lessons(db)
+    chapter, lesson = _make_draft_chapter(db, course.id)
+
+    resp = client.get(f"/api/courses/{course.id}/outline")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["chapters"]) == 1
+    assert body["chapters"][0]["title"] == "Draft Chapter"
+    assert body["chapters"][0]["status"] == "draft"
+    assert len(body["chapters"][0]["lessons"]) == 1
+    assert body["chapters"][0]["lessons"][0]["source_refs"] == ["chunk1"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/courses/{id}/outline — 404 for unknown course
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_get_outline_unknown_course_404(client, db):
+    resp = client.get(f"/api/courses/{uuid.uuid4()}/outline")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/courses/{id}/outline/generate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_generate_outline_enqueues_and_returns_run_id(client, db):
+    course, _ = make_course_with_lessons(db)
+    _make_ready_doc(db, course.id)
+
+    # BackgroundTasks will try to call generate_outline; patch it out.
+    with patch(
+        "app.api.outline_api._run_outline_bg", new_callable=AsyncMock
+    ) as mock_bg:
+        resp = client.post(
+            f"/api/courses/{course.id}/outline/generate",
+            json={},
+        )
+
+    assert resp.status_code == 202
+    body = resp.json()
+    assert "run_id" in body
+    assert body["status"] == GenerationRunStatus.QUEUED
+
+    # GenerationRun persisted
+    run = db.query(GenerationRun).filter(GenerationRun.id == body["run_id"]).first()
+    assert run is not None
+    assert run.course_id == course.id
+
+
+@pytest.mark.integration
+def test_generate_outline_no_ready_docs_422(client, db):
+    course, _ = make_course_with_lessons(db)
+    # no documents at all
+
+    resp = client.post(f"/api/courses/{course.id}/outline/generate", json={})
+    assert resp.status_code == 422
+
+
+@pytest.mark.integration
+def test_generate_outline_unknown_course_404(client, db):
+    resp = client.post(
+        f"/api/courses/{uuid.uuid4()}/outline/generate", json={}
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/courses/{id}/outline — rename
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_patch_outline_renames_chapter(client, db):
+    course, _ = make_course_with_lessons(db)
+    chapter, lesson = _make_draft_chapter(db, course.id)
+
+    resp = client.patch(
+        f"/api/courses/{course.id}/outline",
+        json={
+            "chapters": [
+                {
+                    "id": chapter.id,
+                    "title": "Renamed Chapter",
+                    "lessons": [
+                        {"id": lesson.id, "title": "Renamed Lesson"}
+                    ],
+                }
+            ]
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["chapters"][0]["title"] == "Renamed Chapter"
+    assert body["chapters"][0]["lessons"][0]["title"] == "Renamed Lesson"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/courses/{id}/outline — reorder
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_patch_outline_reorders_chapters(client, db):
+    course, _ = make_course_with_lessons(db)
+    ch0, _ = _make_draft_chapter(db, course.id, title="Chapter A", order_index=0)
+    ch1, _ = _make_draft_chapter(db, course.id, title="Chapter B", order_index=1)
+
+    resp = client.patch(
+        f"/api/courses/{course.id}/outline",
+        json={
+            "chapters": [
+                {"id": ch0.id, "order_index": 1, "lessons": []},
+                {"id": ch1.id, "order_index": 0, "lessons": []},
+            ]
+        },
+    )
+    assert resp.status_code == 200
+
+    db.refresh(ch0)
+    db.refresh(ch1)
+    assert ch0.order_index == 1
+    assert ch1.order_index == 0
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/courses/{id}/outline — delete chapter
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_patch_outline_deletes_chapter(client, db):
+    course, _ = make_course_with_lessons(db)
+    chapter, lesson = _make_draft_chapter(db, course.id)
+
+    resp = client.patch(
+        f"/api/courses/{course.id}/outline",
+        json={"chapters": [{"id": chapter.id, "delete": True, "lessons": []}]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["chapters"] == []
+
+    assert db.query(Chapter).filter(Chapter.id == chapter.id).first() is None
+    assert db.query(Lesson).filter(Lesson.id == lesson.id).first() is None
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/courses/{id}/outline — delete lesson only
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_patch_outline_deletes_lesson(client, db):
+    course, _ = make_course_with_lessons(db)
+    chapter, lesson = _make_draft_chapter(db, course.id)
+
+    resp = client.patch(
+        f"/api/courses/{course.id}/outline",
+        json={
+            "chapters": [
+                {
+                    "id": chapter.id,
+                    "lessons": [{"id": lesson.id, "delete": True}],
+                }
+            ]
+        },
+    )
+    assert resp.status_code == 200
+    assert db.query(Lesson).filter(Lesson.id == lesson.id).first() is None
+    # Chapter still exists
+    assert db.query(Chapter).filter(Chapter.id == chapter.id).first() is not None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/generation-runs/{run_id}
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_get_generation_run_returns_status(client, db):
+    course, _ = make_course_with_lessons(db)
+    run = _make_run(db, course.id, status=GenerationRunStatus.DONE)
+
+    resp = client.get(f"/api/generation-runs/{run.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == run.id
+    assert body["status"] == GenerationRunStatus.DONE
+    assert body["course_id"] == course.id
+
+
+@pytest.mark.integration
+def test_get_generation_run_unknown_404(client, db):
+    resp = client.get(f"/api/generation-runs/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.integration
+def test_get_generation_run_running_has_stage(client, db):
+    course, _ = make_course_with_lessons(db)
+    run = GenerationRun(
+        id=str(uuid.uuid4()),
+        course_id=course.id,
+        doc_ids_json=json.dumps([]),
+        status=GenerationRunStatus.RUNNING,
+        stage="map_1/2",
+        prompt_version="v1",
+        created_at="2026-01-01T00:00:00",
+    )
+    db.add(run)
+    db.commit()
+
+    resp = client.get(f"/api/generation-runs/{run.id}")
+    assert resp.status_code == 200
+    assert resp.json()["stage"] == "map_1/2"

--- a/services/ai/tests/unit/test_lesson_service.py
+++ b/services/ai/tests/unit/test_lesson_service.py
@@ -1,0 +1,384 @@
+"""Unit tests for lesson_service — Phase 3 course builder.
+
+All LLM calls mocked; uses in-memory SQLite for DB assertions.
+"""
+import json
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.db.models import (
+    Base,
+    Chapter,
+    ChunkParent,
+    Course,
+    GenerationRun,
+    GenerationRunStatus,
+    Lesson,
+    OptionChoice,
+    Question,
+    Quiz,
+    QuizScope,
+    Section,
+)
+from app.services.lesson_service import (
+    CONTENT_PROMPT_VERSION,
+    _compute_hash,
+    _load_context,
+    _persist_quiz,
+    process_lesson,
+    publish_course,
+)
+
+
+# ---------------------------------------------------------------------------
+# DB fixture
+# ---------------------------------------------------------------------------
+
+def _make_db():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    section = Section(id=str(uuid.uuid4()), title="Test")
+    db.add(section)
+    course = Course(id=str(uuid.uuid4()), title="Test Course", section_id=section.id)
+    db.add(course)
+    db.commit()
+    return db, course
+
+
+def _add_chapter(db, course_id, status="draft"):
+    ch = Chapter(
+        id=str(uuid.uuid4()),
+        course_id=course_id,
+        title="Chapter",
+        order_index=0,
+        status=status,
+    )
+    db.add(ch)
+    db.commit()
+    db.refresh(ch)
+    return ch
+
+
+def _add_lesson(db, chapter_id, source_refs=None, status="draft", content=""):
+    ls = Lesson(
+        id=str(uuid.uuid4()),
+        chapter_id=chapter_id,
+        title="Lesson",
+        content=content,
+        order_index=0,
+        status=status,
+        source_refs_json=json.dumps(source_refs) if source_refs is not None else None,
+    )
+    db.add(ls)
+    db.commit()
+    db.refresh(ls)
+    return ls
+
+
+def _add_parent(db, cid, course_id, doc_id="doc1", text="Bitcoin is X. " * 100):
+    p = ChunkParent(
+        id=cid,
+        doc_id=doc_id,
+        course_id=course_id,
+        text=text,
+        citation_section="Intro",
+        citation_page=1,
+    )
+    db.add(p)
+    db.commit()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _compute_hash
+# ---------------------------------------------------------------------------
+
+def test_compute_hash_deterministic():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    ls = _add_lesson(db, ch.id, source_refs=["c1", "c2"])
+    h1 = _compute_hash(ls)
+    h2 = _compute_hash(ls)
+    assert h1 == h2
+    assert len(h1) == 64  # SHA256 hex
+
+
+def test_compute_hash_changes_with_refs():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    ls_a = _add_lesson(db, ch.id, source_refs=["c1"])
+    ls_b = _add_lesson(db, ch.id, source_refs=["c2"])
+    assert _compute_hash(ls_a) != _compute_hash(ls_b)
+
+
+def test_compute_hash_order_independent():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    ls1 = _add_lesson(db, ch.id, source_refs=["c1", "c2"])
+    ls2 = _add_lesson(db, ch.id, source_refs=["c2", "c1"])
+    # sorted refs → same hash
+    assert _compute_hash(ls1) == _compute_hash(ls2)
+
+
+# ---------------------------------------------------------------------------
+# _load_context
+# ---------------------------------------------------------------------------
+
+def test_load_context_returns_items():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    _add_parent(db, "p1", course.id, text="Bitcoin block chain.")
+    _add_parent(db, "p2", course.id, text="Mining difficulty.")
+    ls = _add_lesson(db, ch.id, source_refs=["p1", "p2"])
+    ids, items = _load_context(ls, db)
+    assert ids == ["p1", "p2"]
+    assert len(items) == 2
+    assert items[0]["label"] == "p1"
+    assert "Bitcoin" in items[0]["text"]
+
+
+def test_load_context_caps_at_max():
+    from app.services.lesson_service import MAX_CONTEXT_CHUNKS
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    refs = [f"p{i}" for i in range(MAX_CONTEXT_CHUNKS + 2)]
+    for r in refs:
+        _add_parent(db, r, course.id)
+    ls = _add_lesson(db, ch.id, source_refs=refs)
+    ids, items = _load_context(ls, db)
+    assert len(ids) <= MAX_CONTEXT_CHUNKS
+    assert len(items) <= MAX_CONTEXT_CHUNKS
+
+
+def test_load_context_empty_when_no_refs():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    ls = _add_lesson(db, ch.id, source_refs=None)
+    ids, items = _load_context(ls, db)
+    assert ids == []
+    assert items == []
+
+
+# ---------------------------------------------------------------------------
+# _persist_quiz
+# ---------------------------------------------------------------------------
+
+def test_persist_quiz_creates_db_rows():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    ls = _add_lesson(db, ch.id)
+
+    quiz_data = {
+        "questions": [
+            {
+                "prompt": "What is Bitcoin?",
+                "options": [
+                    {"key": "A", "text": "A digital currency"},
+                    {"key": "B", "text": "A database"},
+                    {"key": "C", "text": "An email protocol"},
+                    {"key": "D", "text": "A social network"},
+                ],
+                "correct_key": "A",
+            }
+        ]
+    }
+    quiz_id = _persist_quiz(ls, quiz_data, db)
+    assert quiz_id is not None
+
+    quiz = db.query(Quiz).filter(Quiz.id == quiz_id).first()
+    assert quiz is not None
+    assert quiz.lesson_id == ls.id
+    assert quiz.scope == QuizScope.LESSON
+
+    questions = db.query(Question).filter(Question.quiz_id == quiz_id).all()
+    assert len(questions) == 1
+
+    opts = db.query(OptionChoice).filter(OptionChoice.question_id == questions[0].id).all()
+    assert len(opts) == 4
+    correct = [o for o in opts if o.is_correct]
+    assert len(correct) == 1
+    assert "A digital currency" in correct[0].label
+
+
+def test_persist_quiz_replaces_existing():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    ls = _add_lesson(db, ch.id)
+
+    qdata = {
+        "questions": [
+            {
+                "prompt": "Q1",
+                "options": [{"key": k, "text": f"opt{k}"} for k in ["A", "B", "C", "D"]],
+                "correct_key": "A",
+            }
+        ]
+    }
+    id1 = _persist_quiz(ls, qdata, db)
+    id2 = _persist_quiz(ls, qdata, db)
+
+    # Second call replaced the first
+    quizzes = db.query(Quiz).filter(Quiz.lesson_id == ls.id).all()
+    assert len(quizzes) == 1
+    assert quizzes[0].id == id2
+
+
+# ---------------------------------------------------------------------------
+# process_lesson — full pipeline (LLM mocked)
+# ---------------------------------------------------------------------------
+
+_CONTENT_RESULT = {
+    "content": "Bitcoin is a decentralized currency [ref_1].",
+    "objectives": ["Understand Bitcoin basics"],
+    "glossary": [{"term": "Bitcoin", "definition": "A decentralized digital currency"}],
+    "self_check": ["What is Bitcoin?", "Why is it decentralized?"],
+}
+
+_JUDGE_PASS = {"faithful": True, "issues": []}
+_JUDGE_FAIL = {"faithful": False, "issues": ["Claim X not in source"]}
+
+_QUIZ_RESULT = {
+    "questions": [
+        {
+            "prompt": "What is Bitcoin?",
+            "options": [{"key": k, "text": f"opt{k}"} for k in ["A", "B", "C", "D"]],
+            "correct_key": "A",
+        }
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_process_lesson_published_when_faithful():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    _add_parent(db, "p1", course.id)
+    ls = _add_lesson(db, ch.id, source_refs=["p1"])
+
+    with patch(
+        "app.services.lesson_service.generate_json", new_callable=AsyncMock
+    ) as mock_gj:
+        mock_gj.side_effect = [_CONTENT_RESULT, _JUDGE_PASS, _QUIZ_RESULT]
+        status = await process_lesson(ls.id, db)
+
+    assert status == "published"
+    db.refresh(ls)
+    assert ls.status == "published"
+    assert "Bitcoin" in ls.content
+    assert "Learning Objectives" in ls.content
+    assert ls.content_hash is not None
+
+    # Quiz persisted
+    quiz = db.query(Quiz).filter(Quiz.lesson_id == ls.id).first()
+    assert quiz is not None
+
+
+@pytest.mark.asyncio
+async def test_process_lesson_needs_review_when_unfaithful():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    _add_parent(db, "p1", course.id)
+    ls = _add_lesson(db, ch.id, source_refs=["p1"])
+
+    with patch(
+        "app.services.lesson_service.generate_json", new_callable=AsyncMock
+    ) as mock_gj:
+        mock_gj.side_effect = [_CONTENT_RESULT, _JUDGE_FAIL, _QUIZ_RESULT]
+        status = await process_lesson(ls.id, db)
+
+    assert status == "needs_review"
+    db.refresh(ls)
+    assert ls.status == "needs_review"
+    # Issues embedded in content
+    assert "groundedness_issues" in ls.content
+
+
+@pytest.mark.asyncio
+async def test_process_lesson_skips_on_cache_hit():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    _add_parent(db, "p1", course.id)
+    ls = _add_lesson(db, ch.id, source_refs=["p1"], content="Existing content")
+    ls.content_hash = _compute_hash(ls)
+    db.commit()
+
+    with patch(
+        "app.services.lesson_service.generate_json", new_callable=AsyncMock
+    ) as mock_gj:
+        status = await process_lesson(ls.id, db)
+
+    assert status == "skipped"
+    mock_gj.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_lesson_needs_review_when_no_source_refs():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id)
+    ls = _add_lesson(db, ch.id, source_refs=None)
+
+    with patch(
+        "app.services.lesson_service.generate_json", new_callable=AsyncMock
+    ) as mock_gj:
+        status = await process_lesson(ls.id, db)
+
+    assert status == "needs_review"
+    mock_gj.assert_not_called()
+    db.refresh(ls)
+    assert ls.status == "needs_review"
+
+
+# ---------------------------------------------------------------------------
+# publish_course
+# ---------------------------------------------------------------------------
+
+def test_publish_course_publishes_all_lessons():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id, status="draft")
+    ls1 = _add_lesson(db, ch.id, status="published", content="content")
+    ls2 = _add_lesson(db, ch.id, status="published", content="content")
+
+    result = publish_course(course.id, db)
+    assert result["published_chapters"] == 1
+    assert result["published_lessons"] == 2
+    assert result["skipped_chapters"] == 0
+
+    db.refresh(ch)
+    assert ch.status == "published"
+
+
+def test_publish_course_skips_chapters_with_needs_review():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id, status="draft")
+    _add_lesson(db, ch.id, status="published", content="ok")
+    _add_lesson(db, ch.id, status="needs_review", content="problematic")
+
+    result = publish_course(course.id, db)
+    assert result["published_chapters"] == 0
+    assert result["skipped_chapters"] == 1
+
+    db.refresh(ch)
+    assert ch.status == "draft"
+
+
+def test_publish_course_skips_already_published():
+    db, course = _make_db()
+    ch = _add_chapter(db, course.id, status="published")  # already published
+    _add_lesson(db, ch.id, status="published", content="ok")
+
+    result = publish_course(course.id, db)
+    # Chapter already published → not in draft → not touched
+    assert result["published_chapters"] == 0

--- a/services/ai/tests/unit/test_outline_service.py
+++ b/services/ai/tests/unit/test_outline_service.py
@@ -1,0 +1,464 @@
+"""Unit tests for outline_service — map/reduce/persist pipeline.
+
+All /generate_json calls are mocked; no LLM or DB I/O in these tests.
+"""
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.db.models import (
+    Chapter,
+    ChunkParent,
+    CourseDocument,
+    DocumentStatus,
+    GenerationRun,
+    GenerationRunStatus,
+    Lesson,
+)
+from app.services import outline_service
+from app.services.outline_service import (
+    _collect_chunk_ids,
+    _map_section,
+    _reduce,
+    _persist_outline,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _doc(doc_id="doc1", status=DocumentStatus.READY, tree=None):
+    d = MagicMock(spec=CourseDocument)
+    d.id = doc_id
+    d.status = status
+    d.section_tree_json = json.dumps(tree) if tree is not None else None
+    return d
+
+
+def _parent(cid, text="word " * 50, section="Intro", page=1):
+    p = MagicMock(spec=ChunkParent)
+    p.id = cid
+    p.text = text
+    p.citation_section = section
+    p.citation_page = page
+    return p
+
+
+_SECTION = {
+    "title": "Chapter One",
+    "level": 1,
+    "page_start": 1,
+    "page_end": 10,
+    "parent_chunk_ids": ["p1", "p2"],
+    "children": [
+        {
+            "title": "Section 1.1",
+            "level": 2,
+            "page_start": 2,
+            "page_end": 5,
+            "parent_chunk_ids": ["p3"],
+            "children": [],
+        }
+    ],
+}
+
+_MAP_RESULT = {
+    "lessons": [
+        {
+            "title": "What is Bitcoin",
+            "key_concepts": ["blockchain", "mining"],
+            "difficulty": "beginner",
+        }
+    ]
+}
+
+_REDUCE_RESULT = {
+    "chapters": [
+        {
+            "title": "Introduction",
+            "description": "Foundations",
+            "lessons": [
+                {
+                    "title": "What is Bitcoin",
+                    "description": "Overview",
+                    "objectives": ["Understand basics"],
+                    "candidate_indices": [0],
+                }
+            ],
+        }
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# _collect_chunk_ids
+# ---------------------------------------------------------------------------
+
+def test_collect_chunk_ids_bfs_order():
+    ids = _collect_chunk_ids(_SECTION)
+    # p1, p2 from the top level, then p3 from child
+    assert ids == ["p1", "p2", "p3"]
+
+
+def test_collect_chunk_ids_respects_max():
+    ids = _collect_chunk_ids(_SECTION, max_chunks=2)
+    assert ids == ["p1", "p2"]
+
+
+def test_collect_chunk_ids_empty_section():
+    ids = _collect_chunk_ids({"title": "Empty", "parent_chunk_ids": [], "children": []})
+    assert ids == []
+
+
+# ---------------------------------------------------------------------------
+# _map_section
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_map_section_returns_candidates():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [
+        _parent("p1"), _parent("p2"), _parent("p3")
+    ]
+
+    with patch(
+        "app.services.outline_service.generate_json", new_callable=AsyncMock
+    ) as mock_gj:
+        mock_gj.return_value = _MAP_RESULT
+        result = await _map_section(_SECTION, "doc1", db)
+
+    assert len(result) == 1
+    assert result[0]["title"] == "What is Bitcoin"
+    assert result[0]["source_chunk_ids"] == ["p1", "p2", "p3"]
+    assert result[0]["source_doc_id"] == "doc1"
+
+
+@pytest.mark.asyncio
+async def test_map_section_no_chunks_returns_empty():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = []
+
+    section_no_chunks = {**_SECTION, "parent_chunk_ids": [], "children": []}
+    result = await _map_section(section_no_chunks, "doc1", db)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _reduce
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reduce_returns_outline():
+    candidates = [
+        {
+            "title": "What is Bitcoin",
+            "key_concepts": ["blockchain"],
+            "difficulty": "beginner",
+            "source_chunk_ids": ["p1"],
+            "source_doc_id": "doc1",
+        }
+    ]
+
+    with patch(
+        "app.services.outline_service.generate_json", new_callable=AsyncMock
+    ) as mock_gj:
+        mock_gj.return_value = _REDUCE_RESULT
+        result = await _reduce(candidates)
+
+    assert "chapters" in result
+    assert result["chapters"][0]["title"] == "Introduction"
+    # Verify the prompt included the candidate title
+    call_prompt = mock_gj.call_args[0][0]
+    assert "What is Bitcoin" in call_prompt
+
+
+# ---------------------------------------------------------------------------
+# _persist_outline
+# ---------------------------------------------------------------------------
+
+def test_persist_outline_creates_chapters_and_lessons():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+    from app.db.models import Base, Course, Section
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    section = Section(id=str(uuid.uuid4()), title="Test")
+    db.add(section)
+    course = Course(id=str(uuid.uuid4()), title="Test Course", section_id=section.id)
+    db.add(course)
+    db.commit()
+
+    candidates = [
+        {
+            "title": "Candidate A",
+            "key_concepts": ["bitcoin"],
+            "difficulty": "beginner",
+            "source_chunk_ids": ["chunk1", "chunk2"],
+            "source_doc_id": "doc1",
+        },
+        {
+            "title": "Candidate B",
+            "key_concepts": ["mining"],
+            "difficulty": "intermediate",
+            "source_chunk_ids": ["chunk3"],
+            "source_doc_id": "doc1",
+        },
+    ]
+    outline = {
+        "chapters": [
+            {
+                "title": "Chapter 1",
+                "description": "First chapter",
+                "lessons": [
+                    {
+                        "title": "Lesson 1",
+                        "description": "First lesson",
+                        "objectives": ["Learn basics"],
+                        "candidate_indices": [0, 1],
+                    }
+                ],
+            }
+        ]
+    }
+
+    _persist_outline(course.id, outline, candidates, db)
+
+    chapters = db.query(Chapter).filter(Chapter.course_id == course.id).all()
+    assert len(chapters) == 1
+    assert chapters[0].title == "Chapter 1"
+    assert chapters[0].status == "draft"
+
+    lessons = db.query(Lesson).filter(Lesson.chapter_id == chapters[0].id).all()
+    assert len(lessons) == 1
+    assert lessons[0].title == "Lesson 1"
+    assert lessons[0].status == "draft"
+
+    refs = json.loads(lessons[0].source_refs_json)
+    # chunk1, chunk2 from candidate 0; chunk3 from candidate 1; deduped
+    assert refs == ["chunk1", "chunk2", "chunk3"]
+
+    db.close()
+
+
+def test_persist_outline_replaces_previous_drafts():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+    from app.db.models import Base, Course, Section
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    section = Section(id=str(uuid.uuid4()), title="Test")
+    db.add(section)
+    course = Course(id=str(uuid.uuid4()), title="Test Course", section_id=section.id)
+    db.add(course)
+    db.commit()
+
+    # Pre-existing draft chapter
+    old_chapter = Chapter(
+        id=str(uuid.uuid4()),
+        course_id=course.id,
+        title="Old Chapter",
+        order_index=0,
+        status="draft",
+    )
+    db.add(old_chapter)
+    db.commit()
+
+    outline = {
+        "chapters": [
+            {
+                "title": "New Chapter",
+                "description": "",
+                "lessons": [
+                    {
+                        "title": "New Lesson",
+                        "description": "",
+                        "objectives": ["obj"],
+                        "candidate_indices": [0],
+                    }
+                ],
+            }
+        ]
+    }
+    candidates = [
+        {
+            "title": "X",
+            "source_chunk_ids": ["c1"],
+            "source_doc_id": "d1",
+            "key_concepts": [],
+            "difficulty": "beginner",
+        }
+    ]
+
+    _persist_outline(course.id, outline, candidates, db)
+
+    chapters = db.query(Chapter).filter(Chapter.course_id == course.id).all()
+    assert len(chapters) == 1
+    assert chapters[0].title == "New Chapter"
+
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# generate_outline (full pipeline, integration with mocked LLM)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_generate_outline_full_pipeline():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+    from app.db.models import Base, Course, Section
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    section_row = Section(id=str(uuid.uuid4()), title="Test")
+    db.add(section_row)
+    course = Course(id=str(uuid.uuid4()), title="Course", section_id=section_row.id)
+    db.add(course)
+    db.commit()
+
+    tree = [_SECTION]
+    doc = CourseDocument(
+        id=str(uuid.uuid4()),
+        course_id=course.id,
+        filename="test.pdf",
+        size=1000,
+        status=DocumentStatus.READY,
+        section_tree_json=json.dumps(tree),
+    )
+    db.add(doc)
+
+    run = GenerationRun(
+        id=str(uuid.uuid4()),
+        course_id=course.id,
+        doc_ids_json=json.dumps([doc.id]),
+        status=GenerationRunStatus.QUEUED,
+        prompt_version="v1",
+        created_at="2026-01-01T00:00:00",
+    )
+    db.add(run)
+
+    parent = ChunkParent(
+        id="p1",
+        doc_id=doc.id,
+        course_id=course.id,
+        text="Bitcoin is a decentralized digital currency. " * 30,
+        citation_section="Chapter One",
+        citation_page=1,
+    )
+    db.add(parent)
+    db.commit()
+
+    with patch(
+        "app.services.outline_service.generate_json", new_callable=AsyncMock
+    ) as mock_gj:
+        # First call = map, subsequent calls = reduce (only one doc/section here)
+        mock_gj.side_effect = [_MAP_RESULT, _REDUCE_RESULT]
+        await outline_service.generate_outline(
+            course_id=course.id,
+            doc_ids=[doc.id],
+            db=db,
+            run_id=run.id,
+        )
+
+    db.refresh(run)
+    assert run.status == GenerationRunStatus.DONE
+    assert run.finished_at is not None
+
+    chapters = db.query(Chapter).filter(Chapter.course_id == course.id).all()
+    assert len(chapters) == 1
+    assert chapters[0].title == "Introduction"
+
+    lessons = db.query(Lesson).all()
+    assert len(lessons) == 1
+    assert lessons[0].title == "What is Bitcoin"
+    assert lessons[0].status == "draft"
+    assert lessons[0].source_refs_json is not None
+
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_generate_outline_marks_error_on_no_candidates():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+    from app.db.models import Base, Course, Section
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    section_row = Section(id=str(uuid.uuid4()), title="Test")
+    db.add(section_row)
+    course = Course(id=str(uuid.uuid4()), title="Course", section_id=section_row.id)
+    db.add(course)
+    db.commit()
+
+    # Document with no parent chunks → no candidates
+    doc = CourseDocument(
+        id=str(uuid.uuid4()),
+        course_id=course.id,
+        filename="empty.pdf",
+        size=100,
+        status=DocumentStatus.READY,
+        section_tree_json=None,  # forces rebuild → empty
+    )
+    db.add(doc)
+
+    run = GenerationRun(
+        id=str(uuid.uuid4()),
+        course_id=course.id,
+        doc_ids_json=json.dumps([doc.id]),
+        status=GenerationRunStatus.QUEUED,
+        prompt_version="v1",
+        created_at="2026-01-01T00:00:00",
+    )
+    db.add(run)
+    db.commit()
+
+    await outline_service.generate_outline(
+        course_id=course.id,
+        doc_ids=[doc.id],
+        db=db,
+        run_id=run.id,
+    )
+
+    db.refresh(run)
+    assert run.status == GenerationRunStatus.ERROR
+    assert run.error_message is not None
+
+    db.close()

--- a/services/ai/tests/unit/test_qvac_pipeline.py
+++ b/services/ai/tests/unit/test_qvac_pipeline.py
@@ -261,17 +261,18 @@ def test_split_paragraph_no_overlap_produces_disjoint_starts():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.unit
-def test_build_parent_child_returns_two_lists():
+def test_build_parent_child_returns_three_lists():
     pages = [{"page": 1, "text": "Bitcoin uses UTXO. " * 5}]
-    parents, children = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
+    parents, children, sections = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
     assert isinstance(parents, list)
     assert isinstance(children, list)
+    assert isinstance(sections, list)
 
 
 @pytest.mark.unit
 def test_build_parent_child_non_empty_for_real_text():
     pages = [{"page": 1, "text": "Bitcoin is a peer-to-peer electronic cash system. " * 30}]
-    parents, children = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
+    parents, children, _ = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
     assert len(parents) > 0
     assert len(children) > 0
 
@@ -279,7 +280,7 @@ def test_build_parent_child_non_empty_for_real_text():
 @pytest.mark.unit
 def test_build_parent_child_every_child_has_valid_parent_id():
     pages = [{"page": 1, "text": "Satoshi Nakamoto published the Bitcoin whitepaper in 2008. " * 30}]
-    parents, children = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
+    parents, children, _ = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
     parent_ids = {p["id"] for p in parents}
     for child in children:
         assert child["parent_id"] in parent_ids, f"Child parent_id {child['parent_id']!r} not in parents"
@@ -288,7 +289,7 @@ def test_build_parent_child_every_child_has_valid_parent_id():
 @pytest.mark.unit
 def test_build_parent_child_ids_follow_naming_convention():
     pages = [{"page": 1, "text": "Bitcoin uses UTXO. " * 40}]
-    parents, children = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
+    parents, children, _ = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
     for p in parents:
         assert p["id"].startswith("DOC1_p"), f"Parent id format wrong: {p['id']}"
     for c in children:
@@ -299,14 +300,14 @@ def test_build_parent_child_ids_follow_naming_convention():
 def test_build_parent_child_table_block_produces_table_child():
     table_text = "| Col1 | Col2 |\n|------|------|\n| A    | B    |\n| C    | D    |"
     pages = [{"page": 1, "text": table_text}]
-    _, children = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
+    _, children, _ = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
     table_children = [c for c in children if c["chunk_type"] == "table"]
     assert len(table_children) > 0
 
 
 @pytest.mark.unit
 def test_build_parent_child_empty_pages_returns_empty():
-    parents, children = pipeline_mod.build_parent_child_chunks([], "DOC1")
+    parents, children, _ = pipeline_mod.build_parent_child_chunks([], "DOC1")
     assert parents == []
     assert children == []
 

--- a/services/ai/tests/unit/test_qvac_structured.py
+++ b/services/ai/tests/unit/test_qvac_structured.py
@@ -1,0 +1,119 @@
+"""Unit tests for app/services/qvac_structured.py.
+
+The httpx client is patched — no QVAC service is contacted. Backoff sleeps
+are patched to keep the suite fast.
+"""
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.services import qvac_structured
+from app.services.qvac_structured import (
+    LlmDisabledError,
+    StructuredGenerationError,
+    generate_json,
+)
+
+SCHEMA = {"type": "object", "required": ["answer"], "properties": {"answer": {"type": "string"}}}
+
+
+def _response(status_code: int, body: dict) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=body,
+        request=httpx.Request("POST", "http://localhost:3001/generate_json"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_returns_json_on_success():
+    post = AsyncMock(return_value=_response(200, {"json": {"answer": "ok"}, "attempts": 1}))
+    with patch.object(qvac_structured._client, "post", post):
+        result = await generate_json("say ok", SCHEMA)
+    assert result == {"answer": "ok"}
+    post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_payload_includes_optional_fields():
+    post = AsyncMock(return_value=_response(200, {"json": {}, "attempts": 1}))
+    with patch.object(qvac_structured._client, "post", post):
+        await generate_json(
+            "task",
+            SCHEMA,
+            context=[{"label": "p. 1", "text": "ctx"}],
+            system_prompt="be precise",
+            max_retries=1,
+            generation_params={"temp": 0.0},
+        )
+    payload = post.await_args.kwargs["json"]
+    assert payload["prompt"] == "task"
+    assert payload["schema"] == SCHEMA
+    assert payload["context"] == [{"label": "p. 1", "text": "ctx"}]
+    assert payload["systemPrompt"] == "be precise"
+    assert payload["maxRetries"] == 1
+    assert payload["generationParams"] == {"temp": 0.0}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_503_raises_llm_disabled():
+    post = AsyncMock(return_value=_response(503, {"error": "LLM disabled"}))
+    with patch.object(qvac_structured._client, "post", post):
+        with pytest.raises(LlmDisabledError):
+            await generate_json("x", SCHEMA)
+    post.assert_awaited_once()  # not retried
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_422_raises_structured_generation_error_with_details():
+    body = {"error": "validation failed", "errors": ["$.answer: required"], "raw": "{}"}
+    post = AsyncMock(return_value=_response(422, body))
+    with patch.object(qvac_structured._client, "post", post):
+        with pytest.raises(StructuredGenerationError) as exc_info:
+            await generate_json("x", SCHEMA)
+    assert exc_info.value.errors == ["$.answer: required"]
+    assert exc_info.value.raw == "{}"
+    post.assert_awaited_once()  # not retried
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_transport_error_is_retried_then_succeeds():
+    post = AsyncMock(
+        side_effect=[
+            httpx.ConnectError("refused"),
+            _response(200, {"json": {"answer": "ok"}, "attempts": 1}),
+        ]
+    )
+    with patch.object(qvac_structured._client, "post", post), \
+         patch("app.services.qvac_structured.asyncio.sleep", new_callable=AsyncMock):
+        result = await generate_json("x", SCHEMA)
+    assert result == {"answer": "ok"}
+    assert post.await_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_5xx_is_retried_then_raises_after_exhaustion():
+    post = AsyncMock(return_value=_response(500, {"error": "boom"}))
+    with patch.object(qvac_structured._client, "post", post), \
+         patch("app.services.qvac_structured.asyncio.sleep", new_callable=AsyncMock):
+        with pytest.raises(httpx.HTTPStatusError):
+            await generate_json("x", SCHEMA)
+    assert post.await_count == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_persistent_transport_error_raises_last_exception():
+    post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    with patch.object(qvac_structured._client, "post", post), \
+         patch("app.services.qvac_structured.asyncio.sleep", new_callable=AsyncMock):
+        with pytest.raises(httpx.ConnectError):
+            await generate_json("x", SCHEMA)
+    assert post.await_count == 3

--- a/services/ai/tests/unit/test_section_tree.py
+++ b/services/ai/tests/unit/test_section_tree.py
@@ -1,0 +1,188 @@
+"""Unit tests for section-tree extraction (course builder Fase 1).
+
+Covers the section events collected by build_parent_child_chunks, the
+nesting logic of build_section_tree, and the chunk_parent backfill path.
+All functions are pure — no DB or services involved.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+import app.workers.pipeline as pipeline_mod
+
+# Long enough that every block clears the chunker's minimum word thresholds.
+_PARA = "Bitcoin transactions consume unspent outputs and create new ones. " * 12
+
+
+def _pages_with_headings() -> list[dict]:
+    return [
+        {"page": 1, "text": f"{_PARA}\n\n# Chapter One\n\n{_PARA}"},
+        {"page": 2, "text": f"## Section 1.1\n\n{_PARA}\n\n### Detail 1.1.1\n\n{_PARA}"},
+        {"page": 3, "text": f"# Chapter Two\n\n{_PARA}"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Section events from the chunker
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_chunker_collects_section_events_with_levels_and_pages():
+    _, _, events = pipeline_mod.build_parent_child_chunks(_pages_with_headings(), "DOC1")
+    titled = [e for e in events if e["title"]]
+    assert [(e["title"], e["level"], e["page_start"]) for e in titled] == [
+        ("Chapter One", 1, 1),
+        ("Section 1.1", 2, 2),
+        ("Detail 1.1.1", 3, 2),
+        ("Chapter Two", 1, 3),
+    ]
+
+
+@pytest.mark.unit
+def test_chunker_preamble_before_first_heading_gets_untitled_section():
+    _, _, events = pipeline_mod.build_parent_child_chunks(_pages_with_headings(), "DOC1")
+    assert events[0]["title"] == ""
+    assert events[0]["level"] == 1
+    assert len(events[0]["parent_chunk_ids"]) > 0
+
+
+@pytest.mark.unit
+def test_chunker_section_parent_ids_reference_real_parents():
+    parents, _, events = pipeline_mod.build_parent_child_chunks(_pages_with_headings(), "DOC1")
+    parent_ids = {p["id"] for p in parents}
+    collected = [pid for e in events for pid in e["parent_chunk_ids"]]
+    assert len(collected) == len(parents)
+    assert set(collected) == parent_ids
+
+
+@pytest.mark.unit
+def test_chunker_no_headings_yields_single_untitled_event():
+    pages = [{"page": 1, "text": _PARA}]
+    _, _, events = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
+    assert len(events) == 1
+    assert events[0]["title"] == ""
+
+
+@pytest.mark.unit
+def test_chunker_spurious_headings_do_not_create_sections():
+    pages = [{"page": 1, "text": f"# 32\n\n# P R O L O G U E\n\n# Real Heading\n\n{_PARA}"}]
+    _, _, events = pipeline_mod.build_parent_child_chunks(pages, "DOC1")
+    assert [e["title"] for e in events] == ["Real Heading"]
+
+
+# ---------------------------------------------------------------------------
+# build_section_tree
+# ---------------------------------------------------------------------------
+
+def _event(title: str, level: int, page: int, ids: list[str] | None = None) -> dict:
+    return {
+        "title": title,
+        "level": level,
+        "page_start": page,
+        "page_end": page,
+        "parent_chunk_ids": ids or [],
+    }
+
+
+@pytest.mark.unit
+def test_tree_nests_by_heading_level():
+    tree = pipeline_mod.build_section_tree([
+        _event("Ch 1", 1, 1),
+        _event("Sec 1.1", 2, 2),
+        _event("Sub 1.1.1", 3, 3),
+        _event("Sec 1.2", 2, 4),
+        _event("Ch 2", 1, 5),
+    ])
+    assert [n["title"] for n in tree] == ["Ch 1", "Ch 2"]
+    ch1 = tree[0]
+    assert [n["title"] for n in ch1["children"]] == ["Sec 1.1", "Sec 1.2"]
+    assert [n["title"] for n in ch1["children"][0]["children"]] == ["Sub 1.1.1"]
+
+
+@pytest.mark.unit
+def test_tree_page_end_propagates_from_descendants():
+    tree = pipeline_mod.build_section_tree([
+        _event("Ch 1", 1, 1),
+        _event("Sec 1.1", 2, 2),
+        {"title": "Sub", "level": 3, "page_start": 3, "page_end": 9, "parent_chunk_ids": []},
+        _event("Ch 2", 1, 10),
+    ])
+    assert tree[0]["page_end"] == 9
+    assert tree[0]["children"][0]["page_end"] == 9
+
+
+@pytest.mark.unit
+def test_tree_skipped_level_attaches_to_nearest_shallower_ancestor():
+    # "### Sub" directly under "# Ch" (no ## in between) must still nest.
+    tree = pipeline_mod.build_section_tree([
+        _event("Ch", 1, 1),
+        _event("Sub", 3, 2),
+        _event("Sec", 2, 3),
+    ])
+    ch = tree[0]
+    assert [n["title"] for n in ch["children"]] == ["Sub", "Sec"]
+
+
+@pytest.mark.unit
+def test_tree_empty_events_gives_empty_tree():
+    assert pipeline_mod.build_section_tree([]) == []
+
+
+@pytest.mark.unit
+def test_tree_end_to_end_from_chunker():
+    parents, _, events = pipeline_mod.build_parent_child_chunks(_pages_with_headings(), "DOC1")
+    tree = pipeline_mod.build_section_tree(events)
+    # Preamble + Chapter One + Chapter Two at root level.
+    assert [n["title"] for n in tree] == ["", "Chapter One", "Chapter Two"]
+    ch1 = tree[1]
+    assert ch1["children"][0]["title"] == "Section 1.1"
+    assert ch1["children"][0]["children"][0]["title"] == "Detail 1.1.1"
+    # Chapter One spans through its subsections' pages.
+    assert ch1["page_start"] == 1
+    assert ch1["page_end"] >= 2
+    # Every parent chunk is anchored somewhere in the tree.
+    def _collect(nodes):
+        for n in nodes:
+            yield from n["parent_chunk_ids"]
+            yield from _collect(n["children"])
+    assert set(_collect(tree)) == {p["id"] for p in parents}
+
+
+# ---------------------------------------------------------------------------
+# build_section_events_from_parents (backfill for legacy documents)
+# ---------------------------------------------------------------------------
+
+def _row(pid: str, section: str, page: int) -> SimpleNamespace:
+    return SimpleNamespace(id=pid, citation_section=section, citation_page=page)
+
+
+@pytest.mark.unit
+def test_backfill_groups_consecutive_sections():
+    rows = [
+        _row("d_p0000", "Intro", 1),
+        _row("d_p0001", "Intro", 2),
+        _row("d_p0002", "Mining", 5),
+        _row("d_p0003", "Intro", 9),  # same title later → new run, not merged
+    ]
+    events = pipeline_mod.build_section_events_from_parents(rows)
+    assert [(e["title"], e["page_start"], e["page_end"]) for e in events] == [
+        ("Intro", 1, 2),
+        ("Mining", 5, 5),
+        ("Intro", 9, 9),
+    ]
+    assert events[0]["parent_chunk_ids"] == ["d_p0000", "d_p0001"]
+    assert all(e["level"] == 1 for e in events)
+
+
+@pytest.mark.unit
+def test_backfill_handles_missing_section_and_page():
+    rows = [_row("d_p0000", None, None), _row("d_p0001", "", 0)]
+    events = pipeline_mod.build_section_events_from_parents(rows)
+    assert len(events) == 1
+    assert events[0]["title"] == ""
+    assert events[0]["parent_chunk_ids"] == ["d_p0000", "d_p0001"]
+
+
+@pytest.mark.unit
+def test_backfill_empty_rows():
+    assert pipeline_mod.build_section_events_from_parents([]) == []

--- a/services/ai/tests/unit/test_study_service.py
+++ b/services/ai/tests/unit/test_study_service.py
@@ -127,7 +127,7 @@ def test_parse_citations_preserves_anchor_metadata():
 @pytest.mark.unit
 async def test_generate_calls_qvac_generate_endpoint():
     resp = _make_httpx_resp({"answer": "Bitcoin uses proof-of-work."})
-    with patch("app.services.study_service._qvac_client") as mock_client:
+    with patch("app.services.study_service._qvac_gen_client") as mock_client:
         mock_client.post = AsyncMock(return_value=resp)
         from app.services.study_service import _generate
         result = await _generate(StudyAction.EXPLAIN, "What is PoW?", "[ref_1] context text")
@@ -146,7 +146,7 @@ async def test_generate_calls_qvac_generate_endpoint():
 @pytest.mark.unit
 async def test_generate_passes_action_specific_system_prompt():
     resp = _make_httpx_resp({"answer": "Q1..."})
-    with patch("app.services.study_service._qvac_client") as mock_client:
+    with patch("app.services.study_service._qvac_gen_client") as mock_client:
         mock_client.post = AsyncMock(return_value=resp)
         from app.services.study_service import _generate, _SYSTEM_PROMPTS
         await _generate(StudyAction.QUIZ, "Quiz me.", "some context")
@@ -159,7 +159,7 @@ async def test_generate_passes_action_specific_system_prompt():
 @pytest.mark.unit
 async def test_generate_returns_none_on_qvac_http_error():
     import httpx
-    with patch("app.services.study_service._qvac_client") as mock_client:
+    with patch("app.services.study_service._qvac_gen_client") as mock_client:
         mock_client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
         from app.services.study_service import _generate
         result = await _generate(StudyAction.EXPLAIN, "question", "context")
@@ -171,7 +171,7 @@ async def test_generate_returns_none_on_qvac_http_error():
 @pytest.mark.unit
 async def test_generate_returns_none_on_empty_answer():
     resp = _make_httpx_resp({"answer": ""})
-    with patch("app.services.study_service._qvac_client") as mock_client:
+    with patch("app.services.study_service._qvac_gen_client") as mock_client:
         mock_client.post = AsyncMock(return_value=resp)
         from app.services.study_service import _generate
         result = await _generate(StudyAction.EXPLAIN, "question", "context")

--- a/workers/qvac-service/src/generate-json.js
+++ b/workers/qvac-service/src/generate-json.js
@@ -1,0 +1,257 @@
+/**
+ * Schema-validated JSON generation on the local LLM.
+ *
+ * @qvac/sdk 0.9.x exposes no GBNF grammar or response_format, so validity is
+ * enforced service-side: low-temperature prompting, robust JSON extraction
+ * (code fences, <think> blocks, surrounding prose), validation against a
+ * JSON-Schema subset, and bounded retries that feed the validation errors
+ * back to the model. Callers (course builder outline/lesson jobs) get either
+ * a schema-conformant object or a typed error — never a string to regex.
+ *
+ * Supported schema subset (mirrors the SDK's JsonSchema type): type, enum,
+ * properties, required, additionalProperties, items, plus minItems/maxItems.
+ */
+import { getLlmModelId } from "./models.js";
+import { withLlmLock } from "./llm-queue.js";
+
+const MAX_RETRIES_DEFAULT = parseInt(process.env.QVAC_JSON_MAX_RETRIES ?? "2", 10);
+
+export class LlmDisabledError extends Error {
+  constructor() {
+    super("LLM generation is disabled (QVAC_LLM_ENABLED=false)");
+    this.name = "LlmDisabledError";
+  }
+}
+
+export class JsonGenerationError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ raw?: string, errors?: string[], attempts?: number }} [details]
+   */
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "JsonGenerationError";
+    this.raw = details.raw ?? "";
+    this.errors = details.errors ?? [];
+    this.attempts = details.attempts ?? 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Pulls the first complete JSON object or array out of raw model output.
+ * Tolerates <think> blocks, ```json fences and prose before/after the value.
+ *
+ * @param {string} text
+ * @returns {unknown} the parsed value
+ * @throws {Error} when no parseable JSON is found
+ */
+export function extractJson(text) {
+  let s = (text ?? "").replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
+  // Unwrap a markdown fence if the model added one despite instructions.
+  const fence = s.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) s = fence[1].trim();
+
+  const start = s.search(/[{[]/);
+  if (start === -1) throw new Error("no JSON object or array found in output");
+
+  // Scan for the matching close bracket, honouring strings and escapes.
+  const open = s[start];
+  const close = open === "{" ? "}" : "]";
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < s.length; i++) {
+    const ch = s[i];
+    if (escaped) { escaped = false; continue; }
+    if (ch === "\\") { escaped = true; continue; }
+    if (ch === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (ch === open) depth++;
+    else if (ch === close) {
+      depth--;
+      if (depth === 0) return JSON.parse(s.slice(start, i + 1));
+    }
+  }
+  throw new Error("JSON value is truncated (unbalanced brackets)");
+}
+
+// ---------------------------------------------------------------------------
+// Schema validation
+// ---------------------------------------------------------------------------
+
+function typeOf(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number";
+  return typeof value; // string | boolean | object
+}
+
+function typeMatches(actual, expected) {
+  if (expected === "number") return actual === "number" || actual === "integer";
+  return actual === expected;
+}
+
+/**
+ * Validates a value against the supported JSON-Schema subset.
+ *
+ * @param {unknown} value
+ * @param {object} schema
+ * @param {string} [path]
+ * @returns {string[]} human-readable errors, empty when valid
+ */
+export function validateSchema(value, schema, path = "$") {
+  const errors = [];
+  if (!schema || typeof schema !== "object") return errors;
+
+  if (schema.enum) {
+    if (!schema.enum.includes(value)) {
+      errors.push(`${path}: value ${JSON.stringify(value)} not in enum [${schema.enum.map((v) => JSON.stringify(v)).join(", ")}]`);
+    }
+    return errors;
+  }
+
+  if (schema.type) {
+    const expected = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const actual = typeOf(value);
+    if (!expected.some((t) => typeMatches(actual, t))) {
+      errors.push(`${path}: expected ${expected.join("|")}, got ${actual}`);
+      return errors; // nested checks are meaningless on the wrong type
+    }
+  }
+
+  if (typeOf(value) === "object" && (schema.properties || schema.required)) {
+    for (const key of schema.required ?? []) {
+      if (!(key in value)) errors.push(`${path}.${key}: required property missing`);
+    }
+    for (const [key, propSchema] of Object.entries(schema.properties ?? {})) {
+      if (key in value) errors.push(...validateSchema(value[key], propSchema, `${path}.${key}`));
+    }
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!(key in (schema.properties ?? {}))) {
+          errors.push(`${path}.${key}: additional property not allowed`);
+        }
+      }
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (schema.minItems !== undefined && value.length < schema.minItems) {
+      errors.push(`${path}: expected at least ${schema.minItems} items, got ${value.length}`);
+    }
+    if (schema.maxItems !== undefined && value.length > schema.maxItems) {
+      errors.push(`${path}: expected at most ${schema.maxItems} items, got ${value.length}`);
+    }
+    if (schema.items) {
+      value.forEach((item, i) => errors.push(...validateSchema(item, schema.items, `${path}[${i}]`)));
+    }
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+function buildSystemPrompt(schema, callerPrompt) {
+  const base = callerPrompt ? `${callerPrompt.trim()}\n\n` : "";
+  return (
+    base +
+    "OUTPUT FORMAT — non-negotiable:\n" +
+    "Respond with ONE valid JSON value conforming exactly to this JSON Schema:\n" +
+    JSON.stringify(schema) +
+    "\nRules: output raw JSON only — no markdown fences, no comments, no prose" +
+    " before or after, no trailing commas. Use double quotes for all strings."
+  );
+}
+
+function buildContextBlock(contextBlocks) {
+  if (!contextBlocks?.length) return "";
+  const ctx = contextBlocks
+    .map((b, i) => `[${i + 1}]${b.label ? ` [${b.label}]` : ""}\n${b.text}`)
+    .join("\n\n---\n\n");
+  return `Context:\n${ctx}\n\n`;
+}
+
+/**
+ * Generates a JSON value that validates against *schema*.
+ *
+ * @param {object} params
+ * @param {string} params.prompt          task instruction for the model
+ * @param {{ label?: string, text: string }[]} [params.context]  grounding passages
+ * @param {object} params.schema          JSON Schema (supported subset)
+ * @param {string|null} [params.systemPrompt]  domain instructions, prepended to the format contract
+ * @param {number} [params.maxRetries]    correction rounds after the first attempt
+ * @param {object} [params.generationParams]  llama.cpp sampling overrides
+ * @returns {Promise<{ json: unknown, attempts: number }>}
+ * @throws {LlmDisabledError | JsonGenerationError}
+ */
+export async function generateJson({
+  prompt,
+  context = [],
+  schema,
+  systemPrompt = null,
+  maxRetries = MAX_RETRIES_DEFAULT,
+  generationParams = {},
+}) {
+  const llmId = getLlmModelId();
+  if (!llmId) throw new LlmDisabledError();
+  if (!schema || typeof schema !== "object") {
+    throw new JsonGenerationError("a JSON schema object is required");
+  }
+
+  const { completion } = await import("@qvac/sdk");
+
+  const history = [
+    { role: "system", content: buildSystemPrompt(schema, systemPrompt) },
+    { role: "user", content: `${buildContextBlock(context)}Task: ${prompt} /nothink` },
+  ];
+  // Low temperature favours format compliance; callers may override.
+  const params = { temp: 0.1, ...generationParams };
+
+  let lastRaw = "";
+  let lastErrors = [];
+  const attemptsTotal = 1 + Math.max(0, maxRetries);
+
+  for (let attempt = 1; attempt <= attemptsTotal; attempt++) {
+    const raw = await withLlmLock(async () => {
+      const result = completion({ modelId: llmId, history, stream: false, generationParams: params });
+      return await result.text;
+    });
+    lastRaw = raw ?? "";
+
+    let value;
+    try {
+      value = extractJson(lastRaw);
+    } catch (err) {
+      lastErrors = [`invalid JSON: ${err.message}`];
+      pushCorrectionTurn(history, lastRaw, lastErrors);
+      continue;
+    }
+
+    lastErrors = validateSchema(value, schema);
+    if (lastErrors.length === 0) return { json: value, attempts: attempt };
+    pushCorrectionTurn(history, lastRaw, lastErrors);
+  }
+
+  throw new JsonGenerationError(
+    `model output failed schema validation after ${attemptsTotal} attempts`,
+    { raw: lastRaw, errors: lastErrors, attempts: attemptsTotal },
+  );
+}
+
+function pushCorrectionTurn(history, badOutput, errors) {
+  history.push({ role: "assistant", content: badOutput.slice(0, 2000) });
+  history.push({
+    role: "user",
+    content:
+      "Your previous answer was rejected:\n" +
+      errors.slice(0, 10).map((e) => `- ${e}`).join("\n") +
+      "\nReply again with ONLY the corrected JSON. /nothink",
+  });
+}

--- a/workers/qvac-service/src/llm-queue.js
+++ b/workers/qvac-service/src/llm-queue.js
@@ -1,0 +1,58 @@
+/**
+ * FIFO lock that serialises every LLM call in the service.
+ *
+ * llama.cpp holds a single Qwen3-4B instance: concurrent completions degrade
+ * to interleaved token generation (slower for everyone) or crash on some
+ * backends. The course builder fires bursts of generation jobs, so every
+ * /generate, /stream and /generate_json call must queue here.
+ */
+
+let tail = Promise.resolve();
+
+/**
+ * Acquires the lock. Resolves to a release function once every previously
+ * queued caller has released. Always call release() (use try/finally).
+ *
+ * @returns {Promise<() => void>}
+ */
+export function acquireLlmLock() {
+  let release;
+  const turn = new Promise((resolve) => (release = resolve));
+  const ready = tail;
+  tail = tail.then(() => turn);
+  return ready.then(() => release);
+}
+
+/**
+ * Runs an async function while holding the lock.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+export async function withLlmLock(fn) {
+  const release = await acquireLlmLock();
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Runs an async generator while holding the lock. The lock is held until the
+ * generator is fully consumed (or the consumer breaks/throws), because tokens
+ * keep flowing from the model for the whole iteration.
+ *
+ * @template T
+ * @param {() => AsyncGenerator<T>} genFactory
+ * @returns {AsyncGenerator<T>}
+ */
+export async function* withLlmLockGen(genFactory) {
+  const release = await acquireLlmLock();
+  try {
+    yield* genFactory();
+  } finally {
+    release();
+  }
+}

--- a/workers/qvac-service/src/models.js
+++ b/workers/qvac-service/src/models.js
@@ -10,6 +10,10 @@ import {
 const EMB_SRC = process.env.QVAC_EMB_SRC ?? GTE_LARGE_FP16;
 // Set QVAC_LLM_ENABLED=false to disable LLM generation (retrieval-only mode).
 const LLM_ENABLED = process.env.QVAC_LLM_ENABLED !== "false";
+// Context window for the LLM. Qwen3-4B supports up to 32K natively; 8192 costs
+// ~+0.5 GB of KV cache over the old 4096 default and is required by the course
+// builder (outline/lesson generation). Lower to 4096 on RAM-constrained hosts.
+const LLM_CTX = parseInt(process.env.QVAC_LLM_CTX ?? "8192", 10);
 
 let embeddingModelId = null;
 let llmModelId = null;
@@ -24,11 +28,11 @@ export async function initModels() {
   console.log("\n[qvac] embedding model ready:", embeddingModelId);
 
   if (LLM_ENABLED) {
-    console.log("[qvac] loading LLM (Qwen3-4B Q4_K_M)...");
+    console.log(`[qvac] loading LLM (Qwen3-4B Q4_K_M, ctx_size=${LLM_CTX})...`);
     llmModelId = await loadModel({
       modelSrc: QWEN3_4B_INST_Q4_K_M,
       modelType: "llamacpp-completion",
-      modelConfig: { ctx_size: 4096 },
+      modelConfig: { ctx_size: LLM_CTX },
       onProgress: (p) => process.stdout.write(`\r  ${p.percentage.toFixed(0)}%`),
     });
     console.log("\n[qvac] LLM ready:", llmModelId);
@@ -43,3 +47,4 @@ export async function shutdownModels() {
 
 export function getEmbeddingModelId() { return embeddingModelId; }
 export function getLlmModelId() { return llmModelId; }
+export function getLlmCtxSize() { return LLM_CTX; }

--- a/workers/qvac-service/src/query.js
+++ b/workers/qvac-service/src/query.js
@@ -85,9 +85,13 @@ const DEFAULT_SYSTEM_PROMPT =
  * @param {string} question        student's question
  * @param {{ label: string, text: string }[]} contextBlocks  pre-selected parent chunks
  * @param {string|null} [systemPrompt]  optional override; falls back to DEFAULT_SYSTEM_PROMPT
+ * @param {{ preserveMarkdown?: boolean, enableThinking?: boolean }} [opts]
+ *   preserveMarkdown: skip _stripMarkdown (use for structured study action output)
+ *   enableThinking: omit /nothink suffix (use for DERIVE to leverage Qwen3 reasoning)
  * @returns {{ answer: string }}
  */
-export async function generateFromContext(question, contextBlocks, systemPrompt = null) {
+export async function generateFromContext(question, contextBlocks, systemPrompt = null, opts = {}) {
+  const { preserveMarkdown = false, enableThinking = false } = opts;
   const llmId = getLlmModelId();
 
   if (!llmId) {
@@ -109,9 +113,10 @@ export async function generateFromContext(question, contextBlocks, systemPrompt 
     })
     .join("\n\n---\n\n");
 
+  const thinkSuffix = enableThinking ? "" : " /nothink";
   const userContent = contextStr
-    ? `Contesto:\n${contextStr}\n\nDomanda: ${question} /nothink`
-    : `Domanda: ${question} /nothink`;
+    ? `Contesto:\n${contextStr}\n\nDomanda: ${question}${thinkSuffix}`
+    : `Domanda: ${question}${thinkSuffix}`;
 
   const history = [
     {
@@ -128,7 +133,8 @@ export async function generateFromContext(question, contextBlocks, systemPrompt 
   const result = completion({ modelId: llmId, history, stream: false });
   const rawAnswer = await result.text;
 
-  return { answer: _stripThinking(_stripMarkdown(rawAnswer || "")) };
+  const cleaned = _stripThinking(rawAnswer || "");
+  return { answer: preserveMarkdown ? cleaned : _stripMarkdown(cleaned) };
 }
 
 
@@ -140,9 +146,12 @@ export async function generateFromContext(question, contextBlocks, systemPrompt 
  * @param {string} question
  * @param {{ label: string, text: string }[]} contextBlocks
  * @param {string|null} [systemPrompt]
+ * @param {{ enableThinking?: boolean }} [opts]
+ *   enableThinking: omit /nothink suffix (use for DERIVE)
  * @yields {string} individual tokens as they are produced
  */
-export async function* streamFromContext(question, contextBlocks, systemPrompt = null) {
+export async function* streamFromContext(question, contextBlocks, systemPrompt = null, opts = {}) {
+  const { enableThinking = false } = opts;
   const llmId = getLlmModelId();
 
   if (!llmId) {
@@ -163,9 +172,10 @@ export async function* streamFromContext(question, contextBlocks, systemPrompt =
     })
     .join("\n\n---\n\n");
 
+  const thinkSuffix = enableThinking ? "" : " /nothink";
   const userContent = contextStr
-    ? `Contesto:\n${contextStr}\n\nDomanda: ${question} /nothink`
-    : `Domanda: ${question} /nothink`;
+    ? `Contesto:\n${contextStr}\n\nDomanda: ${question}${thinkSuffix}`
+    : `Domanda: ${question}${thinkSuffix}`;
 
   const history = [
     { role: "system", content: systemPrompt || DEFAULT_SYSTEM_PROMPT },

--- a/workers/qvac-service/src/query.js
+++ b/workers/qvac-service/src/query.js
@@ -2,6 +2,7 @@ import { readFileSync, existsSync } from "fs";
 import path from "path";
 import { ragSearch } from "@qvac/sdk";
 import { getEmbeddingModelId, getLlmModelId } from "./models.js";
+import { withLlmLock, withLlmLockGen } from "./llm-queue.js";
 
 const INGEST_DIR = process.env.QVAC_INGEST_DIR ?? "/qvac_ingest";
 
@@ -130,8 +131,11 @@ export async function generateFromContext(question, contextBlocks, systemPrompt 
   ];
 
   // stream: false → answer is in result.text (Promise), tokenStream is empty.
-  const result = completion({ modelId: llmId, history, stream: false });
-  const rawAnswer = await result.text;
+  // Serialised through the LLM queue: one completion at a time on the model.
+  const rawAnswer = await withLlmLock(async () => {
+    const result = completion({ modelId: llmId, history, stream: false });
+    return await result.text;
+  });
 
   const cleaned = _stripThinking(rawAnswer || "");
   return { answer: preserveMarkdown ? cleaned : _stripMarkdown(cleaned) };
@@ -182,35 +186,38 @@ export async function* streamFromContext(question, contextBlocks, systemPrompt =
     { role: "user", content: userContent },
   ];
 
-  const result = completion({ modelId: llmId, history, stream: true });
+  // Serialised through the LLM queue; the lock is held until the stream ends.
+  yield* withLlmLockGen(async function* () {
+    const result = completion({ modelId: llmId, history, stream: true });
 
-  // Buffer tokens while inside a <think>...</think> block; only yield post-thinking output.
-  let thinking = false;
-  let thinkBuf = "";
-  for await (const token of result.tokenStream) {
-    thinkBuf += token;
-    if (!thinking && thinkBuf.includes("<think>")) {
-      thinking = true;
-    }
-    if (thinking) {
-      if (thinkBuf.includes("</think>")) {
-        thinking = false;
-        // Yield any text that came after the closing tag.
-        const after = thinkBuf.split("</think>").slice(1).join("</think>").trimStart();
-        thinkBuf = "";
-        if (after) yield after;
+    // Buffer tokens while inside a <think>...</think> block; only yield post-thinking output.
+    let thinking = false;
+    let thinkBuf = "";
+    for await (const token of result.tokenStream) {
+      thinkBuf += token;
+      if (!thinking && thinkBuf.includes("<think>")) {
+        thinking = true;
       }
-      // Still inside <think> — swallow the token.
-      continue;
+      if (thinking) {
+        if (thinkBuf.includes("</think>")) {
+          thinking = false;
+          // Yield any text that came after the closing tag.
+          const after = thinkBuf.split("</think>").slice(1).join("</think>").trimStart();
+          thinkBuf = "";
+          if (after) yield after;
+        }
+        // Still inside <think> — swallow the token.
+        continue;
+      }
+      // Normal token — flush the buffer and yield.
+      if (thinkBuf) {
+        yield thinkBuf;
+        thinkBuf = "";
+      }
     }
-    // Normal token — flush the buffer and yield.
-    if (thinkBuf) {
-      yield thinkBuf;
-      thinkBuf = "";
-    }
-  }
-  // Flush any remaining buffer (e.g. model ended without </think>).
-  if (thinkBuf && !thinking) yield thinkBuf;
+    // Flush any remaining buffer (e.g. model ended without </think>).
+    if (thinkBuf && !thinking) yield thinkBuf;
+  });
 }
 
 

--- a/workers/qvac-service/src/server.js
+++ b/workers/qvac-service/src/server.js
@@ -51,21 +51,26 @@ const server = createServer(async (req, res) => {
       return send(res, 200, result);
     }
 
-    // POST /generate  { question: string, context: [{ label: string, text: string }], systemPrompt?: string }
+    // POST /generate  { question: string, context: [{ label: string, text: string }],
+    //                   systemPrompt?: string, preserveMarkdown?: boolean, enableThinking?: boolean }
     // LLM generation from pre-built parent context — no retrieval.
     // systemPrompt overrides the default; omit to use the BitPolito Academy default.
+    // preserveMarkdown: skip _stripMarkdown (pass true for structured study action output).
+    // enableThinking: omit /nothink suffix (pass true for DERIVE to use Qwen3 reasoning).
     // Returns { answer: string }
     if (req.method === "POST" && req.url === "/generate") {
-      const { question, context = [], systemPrompt = null } = await readBody(req);
-      const result = await generateFromContext(question, context, systemPrompt);
+      const { question, context = [], systemPrompt = null, preserveMarkdown = false, enableThinking = false } = await readBody(req);
+      const result = await generateFromContext(question, context, systemPrompt, { preserveMarkdown, enableThinking });
       return send(res, 200, result);
     }
 
-    // POST /stream  { question: string, context: [{ label, text }], systemPrompt?: string }
+    // POST /stream  { question: string, context: [{ label, text }], systemPrompt?: string,
+    //                enableThinking?: boolean }
     // Server-Sent Events stream — writes tokens as "data: <token>\n\n" until done.
     // Client should consume with EventSource or fetch + ReadableStream.
+    // Note: preserveMarkdown is not needed here — streaming tokens are never stripped.
     if (req.method === "POST" && req.url === "/stream") {
-      const { question, context = [], systemPrompt = null } = await readBody(req);
+      const { question, context = [], systemPrompt = null, enableThinking = false } = await readBody(req);
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -73,7 +78,7 @@ const server = createServer(async (req, res) => {
         "Transfer-Encoding": "chunked",
       });
       try {
-        for await (const token of streamFromContext(question, context, systemPrompt)) {
+        for await (const token of streamFromContext(question, context, systemPrompt, { enableThinking })) {
           res.write(`data: ${JSON.stringify(token)}\n\n`);
         }
         res.write("data: [DONE]\n\n");

--- a/workers/qvac-service/src/server.js
+++ b/workers/qvac-service/src/server.js
@@ -2,6 +2,7 @@ import { createServer } from "http";
 import { initModels, shutdownModels } from "./models.js";
 import { ingestFromJsonl } from "./ingest.js";
 import { queryRag, retrieveChunks, generateFromContext, streamFromContext } from "./query.js";
+import { generateJson, LlmDisabledError, JsonGenerationError } from "./generate-json.js";
 
 const PORT = parseInt(process.env.QVAC_PORT ?? "3001", 10);
 
@@ -86,6 +87,28 @@ const server = createServer(async (req, res) => {
         res.write(`data: ${JSON.stringify("[ERROR] " + err.message)}\n\n`);
       }
       return res.end();
+    }
+
+    // POST /generate_json  { prompt: string, schema: object, context?: [{ label?, text }],
+    //                        systemPrompt?: string, maxRetries?: number, generationParams?: object }
+    // Schema-validated JSON generation (course builder: outlines, lesson metadata, judges).
+    // Returns 200 { json, attempts } — json is guaranteed to validate against schema.
+    // 422 when the model cannot produce valid JSON after retries (body has errors + raw).
+    // 503 when the LLM is disabled (QVAC_LLM_ENABLED=false).
+    if (req.method === "POST" && req.url === "/generate_json") {
+      const { prompt, schema, context = [], systemPrompt = null, maxRetries, generationParams } = await readBody(req);
+      try {
+        const result = await generateJson({ prompt, schema, context, systemPrompt, maxRetries, generationParams });
+        return send(res, 200, result);
+      } catch (err) {
+        if (err instanceof LlmDisabledError) {
+          return send(res, 503, { error: err.message });
+        }
+        if (err instanceof JsonGenerationError) {
+          return send(res, 422, { error: err.message, errors: err.errors, raw: err.raw, attempts: err.attempts });
+        }
+        throw err;
+      }
     }
 
     // GET /health — used by FastAPI to detect whether the service is up.

--- a/workers/qvac-service/tests/generate-json.test.js
+++ b/workers/qvac-service/tests/generate-json.test.js
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for src/generate-json.js.
+ *
+ * @qvac/sdk and src/models.js are fully mocked — no model download happens.
+ * The completion mock returns scripted outputs so the extraction, validation
+ * and correction-retry paths can be exercised deterministically.
+ */
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+// ---------------------------------------------------------------------------
+// SDK + models.js mocks — registered before generate-json.js is imported
+// ---------------------------------------------------------------------------
+
+let completionOutputs = [];
+let completionCalls = [];
+
+const mockCompletion = mock.fn((params) => {
+  completionCalls.push(structuredClone(params.history));
+  const next = completionOutputs.shift() ?? "";
+  return { text: Promise.resolve(next) };
+});
+
+await mock.module("@qvac/sdk", {
+  namedExports: {
+    completion: mockCompletion,
+    ragSearch: mock.fn(),
+    ragIngest: mock.fn(),
+    loadModel: mock.fn(),
+    unloadModel: mock.fn(),
+    close: mock.fn(),
+    GTE_LARGE_FP16: {},
+    QWEN3_4B_INST_Q4_K_M: {},
+  },
+});
+
+let llmId = "test-llm-id";
+await mock.module(import.meta.resolve("../src/models.js"), {
+  namedExports: {
+    getEmbeddingModelId: () => "test-emb-id",
+    getLlmModelId: () => llmId,
+    getLlmCtxSize: () => 8192,
+    initModels: mock.fn(),
+    shutdownModels: mock.fn(),
+  },
+});
+
+const { generateJson, extractJson, validateSchema, LlmDisabledError, JsonGenerationError } =
+  await import("../src/generate-json.js");
+
+beforeEach(() => {
+  completionOutputs = [];
+  completionCalls = [];
+  llmId = "test-llm-id";
+});
+
+// ---------------------------------------------------------------------------
+// extractJson
+// ---------------------------------------------------------------------------
+
+describe("extractJson", () => {
+  it("parses bare JSON objects and arrays", () => {
+    assert.deepEqual(extractJson('{"a": 1}'), { a: 1 });
+    assert.deepEqual(extractJson("[1, 2]"), [1, 2]);
+  });
+
+  it("unwraps markdown fences", () => {
+    assert.deepEqual(extractJson('```json\n{"a": 1}\n```'), { a: 1 });
+  });
+
+  it("strips <think> blocks", () => {
+    assert.deepEqual(
+      extractJson('<think>{"draft": true}</think>{"a": 1}'),
+      { a: 1 },
+    );
+  });
+
+  it("ignores prose around the JSON value", () => {
+    assert.deepEqual(extractJson('Here you go: {"a": 1} hope it helps'), { a: 1 });
+  });
+
+  it("handles brackets inside strings", () => {
+    assert.deepEqual(extractJson('{"a": "with } brace and \\" quote"}'), {
+      a: 'with } brace and " quote',
+    });
+  });
+
+  it("throws on truncated JSON", () => {
+    assert.throws(() => extractJson('{"a": [1, 2'), /truncated/);
+  });
+
+  it("throws when no JSON is present", () => {
+    assert.throws(() => extractJson("no json here"), /no JSON/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSchema
+// ---------------------------------------------------------------------------
+
+describe("validateSchema", () => {
+  const schema = {
+    type: "object",
+    required: ["title", "lessons"],
+    properties: {
+      title: { type: "string" },
+      difficulty: { enum: ["easy", "medium", "hard"] },
+      lessons: {
+        type: "array",
+        minItems: 1,
+        items: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string" }, page: { type: "integer" } },
+        },
+      },
+    },
+  };
+
+  it("accepts a conforming value", () => {
+    const value = { title: "Ch. 1", difficulty: "easy", lessons: [{ title: "L1", page: 3 }] };
+    assert.deepEqual(validateSchema(value, schema), []);
+  });
+
+  it("reports missing required properties with their path", () => {
+    const errors = validateSchema({ title: "x", lessons: [{}] }, schema);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /\$\.lessons\[0\]\.title: required/);
+  });
+
+  it("reports type mismatches", () => {
+    const errors = validateSchema({ title: 5, lessons: [] }, schema);
+    assert.ok(errors.some((e) => e.includes("$.title: expected string, got integer")));
+    assert.ok(errors.some((e) => e.includes("at least 1 items")));
+  });
+
+  it("reports enum violations", () => {
+    const errors = validateSchema(
+      { title: "x", difficulty: "extreme", lessons: [{ title: "y" }] },
+      schema,
+    );
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /not in enum/);
+  });
+
+  it("accepts integers where numbers are expected", () => {
+    assert.deepEqual(validateSchema(3, { type: "number" }), []);
+  });
+
+  it("rejects additional properties when additionalProperties is false", () => {
+    const errors = validateSchema(
+      { a: 1, extra: true },
+      { type: "object", properties: { a: { type: "integer" } }, additionalProperties: false },
+    );
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /\$\.extra: additional property/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateJson
+// ---------------------------------------------------------------------------
+
+const SIMPLE_SCHEMA = {
+  type: "object",
+  required: ["answer"],
+  properties: { answer: { type: "string" } },
+};
+
+describe("generateJson", () => {
+  it("returns parsed JSON on the first valid attempt", async () => {
+    completionOutputs = ['{"answer": "ok"}'];
+    const { json, attempts } = await generateJson({
+      prompt: "say ok",
+      schema: SIMPLE_SCHEMA,
+    });
+    assert.deepEqual(json, { answer: "ok" });
+    assert.equal(attempts, 1);
+    assert.equal(completionCalls.length, 1);
+  });
+
+  it("embeds the schema in the system prompt and context in the user turn", async () => {
+    completionOutputs = ['{"answer": "ok"}'];
+    await generateJson({
+      prompt: "summarise",
+      schema: SIMPLE_SCHEMA,
+      context: [{ label: "p. 7", text: "Bitcoin is..." }],
+      systemPrompt: "You are a tutor.",
+    });
+    const [history] = completionCalls;
+    assert.match(history[0].content, /You are a tutor\./);
+    assert.match(history[0].content, /"required":\["answer"\]/);
+    assert.match(history[1].content, /\[p\. 7\]\nBitcoin is\.\.\./);
+    assert.match(history[1].content, /\/nothink/);
+  });
+
+  it("retries with validation feedback and succeeds", async () => {
+    completionOutputs = ["not json at all", '{"answer": 42}', '{"answer": "fixed"}'];
+    const { json, attempts } = await generateJson({
+      prompt: "x",
+      schema: SIMPLE_SCHEMA,
+      maxRetries: 2,
+    });
+    assert.deepEqual(json, { answer: "fixed" });
+    assert.equal(attempts, 3);
+    // Third call's history must carry both correction turns.
+    const lastHistory = completionCalls[2];
+    assert.equal(lastHistory.length, 6); // system, user, asst, user, asst, user
+    assert.match(lastHistory[3].content, /invalid JSON/);
+    assert.match(lastHistory[5].content, /expected string, got integer/);
+  });
+
+  it("throws JsonGenerationError with details after exhausting retries", async () => {
+    completionOutputs = ['{"wrong": 1}', '{"wrong": 2}'];
+    await assert.rejects(
+      generateJson({ prompt: "x", schema: SIMPLE_SCHEMA, maxRetries: 1 }),
+      (err) => {
+        assert.ok(err instanceof JsonGenerationError);
+        assert.equal(err.attempts, 2);
+        assert.ok(err.errors.some((e) => e.includes("required property missing")));
+        assert.equal(err.raw, '{"wrong": 2}');
+        return true;
+      },
+    );
+  });
+
+  it("throws LlmDisabledError when no LLM is loaded", async () => {
+    llmId = null;
+    await assert.rejects(
+      generateJson({ prompt: "x", schema: SIMPLE_SCHEMA }),
+      LlmDisabledError,
+    );
+  });
+
+  it("rejects a missing schema", async () => {
+    await assert.rejects(
+      generateJson({ prompt: "x" }),
+      /schema object is required/,
+    );
+  });
+});

--- a/workers/qvac-service/tests/llm-queue.test.js
+++ b/workers/qvac-service/tests/llm-queue.test.js
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for src/llm-queue.js — FIFO serialisation of LLM calls.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { withLlmLock, withLlmLockGen } from "../src/llm-queue.js";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+describe("withLlmLock", () => {
+  it("serialises concurrent calls in FIFO order", async () => {
+    const events = [];
+    const task = (name, ms) =>
+      withLlmLock(async () => {
+        events.push(`${name}:start`);
+        await sleep(ms);
+        events.push(`${name}:end`);
+      });
+
+    // a is slower but queued first — b must not start until a ends.
+    await Promise.all([task("a", 30), task("b", 5)]);
+    assert.deepEqual(events, ["a:start", "a:end", "b:start", "b:end"]);
+  });
+
+  it("releases the lock when the task throws", async () => {
+    await assert.rejects(
+      withLlmLock(async () => { throw new Error("boom"); }),
+      /boom/,
+    );
+    // Lock must be free again.
+    const result = await withLlmLock(async () => "ok");
+    assert.equal(result, "ok");
+  });
+
+  it("returns the task's value", async () => {
+    assert.equal(await withLlmLock(async () => 42), 42);
+  });
+});
+
+describe("withLlmLockGen", () => {
+  it("holds the lock until the generator is fully consumed", async () => {
+    const events = [];
+
+    async function* tokens() {
+      events.push("gen:first");
+      yield "t1";
+      await sleep(20);
+      events.push("gen:second");
+      yield "t2";
+    }
+
+    const consume = (async () => {
+      for await (const t of withLlmLockGen(tokens)) void t;
+      events.push("gen:done");
+    })();
+    // Queued while the stream is still flowing.
+    const blocked = withLlmLock(async () => events.push("lock:acquired"));
+
+    await Promise.all([consume, blocked]);
+    assert.deepEqual(events, ["gen:first", "gen:second", "gen:done", "lock:acquired"]);
+  });
+
+  it("releases the lock when the consumer breaks early", async () => {
+    async function* tokens() {
+      yield "t1";
+      yield "t2";
+    }
+    for await (const t of withLlmLockGen(tokens)) {
+      void t;
+      break;
+    }
+    const result = await withLlmLock(async () => "free");
+    assert.equal(result, "free");
+  });
+});


### PR DESCRIPTION
- QVAC query.js/server.js: add preserveMarkdown and enableThinking options to generateFromContext/streamFromContext; skip _stripMarkdown for structured study output; omit /nothink only for DERIVE to enable Qwen3 chain-of-thought
- study_service: add _stream_generate, stream_dispatch with SSE keepalive, semantic cache (shared key with dispatch), separate 120s httpx client for generation, per-action enableThinking (DERIVE only), ORAL/COMPARE system prompt hardening with explicit label and dimension enforcement
- study_api: POST /study/stream SSE endpoint with asyncio.wait_for keepalive and X-Accel-Buffering header; per-user JWT rate limit key in rate_limit.py
- study.ts: sendStudyActionStream consuming SSE with citations sentinel parsing
- OutputPane: streaming path for EXPLAIN/SUMMARIZE/DERIVE/COMPARE/OPEN_QUESTIONS, action-streaming message type filtered from localStorage persistence, onActionResult parity between streaming and buffered paths
- StudyOutput: remarkGfm on all ReactMarkdown, robust oral parser with multi-label regex, OralQuestionCard idle/submitted/revealed phases, quiz split regex handles Q1:/Q1. variants, quiz explanation extracted and shown after reveal, retrieval-failed banner
- remark-gfm@3.0.1 added to apps/web dependencies